### PR TITLE
build: add in dispatch search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  find_package(dispatch CONFIG)
   find_package(Foundation CONFIG)
 endif()
 

--- a/Sources/SwiftASN1/CMakeLists.txt
+++ b/Sources/SwiftASN1/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(SwiftASN1
   "Errors.swift")
 
 target_link_libraries(SwiftASN1 PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>)
 set_target_properties(SwiftASN1 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
When building against a build tree artifact for Foundation, we need to add the build tree artifacts of dispatch as that is an exposed dependency for Foundation.