### PR TITLE
Add support for serializing raw bytes.

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -946,7 +946,7 @@ extension DER {
             // We then only need to create a constructed node and append the binary representation in their sorted order
             self.appendConstructedNode(identifier: identifier) { serializer in
                 for range in sortedRanges {
-                    serializer._serializedBytes.append(contentsOf: serializedBytes[range])
+                    serializer.serializeRawBytes(serializedBytes[range])
                 }
             }
         }
@@ -976,9 +976,26 @@ extension DER {
                         coder.serialize(node)
                     }
                 case .primitive(let baseData):
-                    coder._serializedBytes.append(contentsOf: baseData)
+                    coder.serializeRawBytes(baseData)
                 }
             }
+        }
+
+        /// Serializes a sequence of raw bytes directly into the output stream.
+        ///
+        /// This is an extremely low-level helper function that can be used to serialize a parsed object exactly as it was deserialized.
+        /// This can be used to enable perfect fidelity re-encoding where there are equally valid alternatives for serializing something
+        /// and your code makes default choices.
+        ///
+        /// In general, users should avoid calling this function unless it's absolutely necessary to do so as a matter of implementation.
+        ///
+        /// Users are required to ensure that `bytes` is well-formed DER. Failure to do so will lead to invalid output being produced.
+        ///
+        /// - parameters:
+        ///     - bytes: The raw bytes to serialize. These bytes must be well-formed DER.
+        @inlinable
+        public mutating func serializeRawBytes<Bytes: Sequence>(_ bytes: Bytes) where Bytes.Element == UInt8 {
+            self._serializedBytes.append(contentsOf: bytes)
         }
 
         // This is the base logical function that all other append methods are built on. This one has most of the logic, and doesn't

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
@@ -59,7 +59,7 @@ public struct ASN1Any: DERParseable, DERSerializable, Hashable, Sendable {
     @inlinable
     public func serialize(into coder: inout DER.Serializer) throws {
         // Dangerous to just reach in there like this, but it's the right way to serialize this.
-        coder._serializedBytes.append(contentsOf: self._serializedBytes)
+        coder.serializeRawBytes(self._serializedBytes)
     }
 }
 

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -896,4 +896,25 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
         assertSetOfLessThanOrEqual([1, 0], [1, 0])
         assertSetOfLessThanOrEqual([1, 0], [2, 0])
     }
+
+    func testSerializingRawBytes() {
+        var serializer = DER.Serializer()
+        serializer.serializeRawBytes([1, 2, 3, 4])
+
+        XCTAssertEqual(serializer.serializedBytes, [1, 2, 3, 4])
+
+        // A more complex example to prove that we can add the raw bytes at arbitrary locations.
+        serializer = DER.Serializer()
+        serializer.appendConstructedNode(identifier: .sequence) { serializer in
+            serializer.serialize(explicitlyTaggedWithTagNumber: 1, tagClass: .contextSpecific) { serializer in
+                serializer.serializeRawBytes([1, 2, 3, 4])
+            }
+            serializer.serialize(explicitlyTaggedWithTagNumber: 2, tagClass: .contextSpecific) { _ in }
+        }
+
+        XCTAssertEqual(
+            serializer.serializedBytes,
+            [0x30, 0x8, 0xA1, 0x04, 0x01, 0x2, 0x03, 0x04, 0xA2, 0x00]
+        )
+    }
 }


### PR DESCRIPTION
In rare cases it's necessary for users to be able to do an end-run around the serializer. This is most common in cases where some bytes have had a signature calculated over them, and they are being re-encoded. Even though DER is unambiguous, the ASN.1 objects themselves may not be, and may permit multiple valid encodings. Allowing the bytes to be re-serialized as they were preserves the integrity of the signature.