### PR TITLE
Add PEM support through `PEMRepresentable`

### DIFF
--- a/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
@@ -11,12 +11,157 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+/// Defines a type that can be serialized in PEM-encoded form.
+///
+/// Users implementing this type are expected to just provide the ``pemDiscriminator``
+///
+/// Objects that are ``PEMSerializable`` can be serialized to a PEM `String` by constructing a ``PEMSerializer`` and calling ``PEMSerializer/serialize(_:)``.
+public protocol PEMSerializable: DERSerializable {
+    /// The PEM discriminator identifying this object type.
+    ///
+    /// The PEM discriminator is in the first line of a PEM string after `BEGIN` and at the end of the string after `END` i.e.
+    /// ```
+    /// -----BEGIN pemDiscrimiator-----
+    /// <base 64 DER representation of this object>
+    /// -----END pemDiscrimiator-----
+    /// ```
+    static var pemDiscriminator: String { get }
+}
+
+/// Defines a type that can be parsed from a PEM-encoded form.
+///
+/// Users implementing this type are expected to just provide the ``pemDiscriminator``.
+///
+/// Objects that are ``PEMParseable`` can be construct from a PEM `String` through ``PEMParseable/init(pemEncoded:)``.
+public protocol PEMParseable: DERParseable {
+    /// The PEM discriminator identifying this object type.
+    ///
+    /// The PEM discriminator is in the first line of a PEM string after `BEGIN` and at the end of the string after `END` i.e.
+    /// ```
+    /// -----BEGIN pemDiscrimiator-----
+    /// <base 64 DER representation of this object>
+    /// -----END pemDiscrimiator-----
+    /// ```
+    static var pemDiscriminator: String { get }
+}
+
+/// Defines a type that can be serialized in and parsed from PEM-encoded form.
+///
+/// Users implementing this type are expected to just provide the ``pemDiscriminator``.
+///
+/// Objects that are ``PEMRepresentable`` can be construct from a PEM `String` through ``PEMParseable/init(pemEncoded:)``.
+///
+/// A PEM `String` can serialized by constructing a ``PEMSerializer`` and calling ``PEMSerializer/serialize(_:)``.
+public typealias PEMRepresentable = PEMSerializable & PEMParseable
+
 #if canImport(Foundation)
 import Foundation
 
+extension PEMParseable {
+    /// Initialize this object from a serialized PEM representation.
+    ///
+    /// - parameters:
+    ///     - pemEncoded: The PEM-encoded string representing this object.
+    public init(pemEncoded pemString: String) throws {
+        // A PEM document looks like this:
+        //
+        // -----BEGIN <SOME DISCRIMINATOR>-----
+        // <base64 encoded bytes, 64 characters per line>
+        // -----END <SOME DISCRIMINATOR>-----
+        //
+        // This function attempts to parse this string as a PEM document, and returns the discriminator type
+        // and the base64 decoded bytes.
+        var lines = pemString.split { $0.isNewline }[...]
+        guard let first = lines.first, let last = lines.last else {
+            throw ASN1Error.invalidPEMDocument(reason: "Leading or trailing line missing.")
+        }
+
+        guard let discriminator = first.pemStartDiscriminator, discriminator == last.pemEndDiscriminator else {
+            throw ASN1Error.invalidPEMDocument(reason: "Leading or trailing line missing PEM discriminator")
+        }
+
+        // All but the last line must be 64 bytes. The force unwrap is safe because we require the lines to be
+        // greater than zero.
+        lines = lines.dropFirst().dropLast()
+        guard lines.count > 0,
+            lines.dropLast().allSatisfy({ $0.utf8.count == PEMDocument.lineLength }),
+            lines.last!.utf8.count <= PEMDocument.lineLength else {
+            throw ASN1Error.invalidPEMDocument(reason: "PEMDocument has incorrect line lengths")
+        }
+
+        guard discriminator == Self.pemDiscriminator else {
+            throw ASN1Error.invalidPEMDocument(reason: "PEMDocument has incorrect discriminator \(discriminator). Expected \(Self.pemDiscriminator) instead")
+        }
+        
+        guard let derBytes = Data(base64Encoded: lines.joined()) else {
+            throw ASN1Error.invalidPEMDocument(reason: "PEMDocument not correctly base64 encoded")
+        }
+        
+        try self.init(derEncoded: Array(derBytes))
+    }
+}
+
+
+/// An object that can serialize PEM strings through ``PEMSerializer/serialize(_:)``.
+public struct PEMSerializer: Sendable {
+    
+    public init() {}
+    
+    /// Serializes a node as a PEM string.
+    /// - parameters:
+    ///     node: The node to be serialized.
+    public func serialize<Node: PEMSerializable>(_ node: Node) throws -> String {
+        var serializer = DER.Serializer()
+        try serializer.serialize(node)
+        var encoded = Data(serializer.serializedBytes).base64EncodedString()[...]
+        let pemLineCount = (encoded.utf8.count + PEMDocument.lineLength) / PEMDocument.lineLength
+        var pemLines = [Substring]()
+        pemLines.reserveCapacity(pemLineCount + 2)
+        
+        pemLines.append("-----BEGIN \(Node.pemDiscriminator)-----")
+        
+        while encoded.count > 0 {
+            let prefixIndex = encoded.index(encoded.startIndex, offsetBy: PEMDocument.lineLength, limitedBy: encoded.endIndex) ?? encoded.endIndex
+            pemLines.append(encoded[..<prefixIndex])
+            encoded = encoded[prefixIndex...]
+        }
+        
+        pemLines.append("-----END \(Node.pemDiscriminator)-----")
+        
+        return pemLines.joined(separator: "\n")
+    }
+}
+
+extension PEMSerializable {
+    /// Serializes `self` as a PEM string.
+    public var pemString: String {
+        get throws {
+            var serializer = DER.Serializer()
+            try serializer.serialize(self)
+            var encoded = Data(serializer.serializedBytes).base64EncodedString()[...]
+            let pemLineCount = (encoded.utf8.count + PEMDocument.lineLength) / PEMDocument.lineLength
+            var pemLines = [Substring]()
+            pemLines.reserveCapacity(pemLineCount + 2)
+            
+            pemLines.append("-----BEGIN \(Self.pemDiscriminator)-----")
+            
+            while encoded.count > 0 {
+                let prefixIndex = encoded.index(encoded.startIndex, offsetBy: PEMDocument.lineLength, limitedBy: encoded.endIndex) ?? encoded.endIndex
+                pemLines.append(encoded[..<prefixIndex])
+                encoded = encoded[prefixIndex...]
+            }
+            
+            pemLines.append("-----END \(Self.pemDiscriminator)-----")
+            
+            return pemLines.joined(separator: "\n")
+        }
+    }
+}
+
 /// A PEM document is some data, and a discriminator type that is used to advertise the content.
 public struct PEMDocument {
-    private static let lineLength = 64
+    fileprivate static let lineLength = 64
 
     public var type: String
 

--- a/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
@@ -14,7 +14,6 @@
 
 #if canImport(Foundation)
 import Foundation
-#endif
 
 /// Defines a type that can be serialized in PEM-encoded form.
 ///
@@ -157,7 +156,6 @@ public struct PEMDocument {
     public var derBytes: [UInt8]
 
     public init(pemString: String) throws {
-        #if canImport(Foundation)
         // A PEM document looks like this:
         //
         // -----BEGIN <SOME DISCRIMINATOR>-----
@@ -190,9 +188,6 @@ public struct PEMDocument {
 
         self.discriminator = discriminator
         self.derBytes = Array(derBytes)
-        #else
-        fatalError("PEM decoding currently not supported without Foundation.")
-        #endif
     }
 
     public init(type: String, derBytes: [UInt8]) {
@@ -200,7 +195,6 @@ public struct PEMDocument {
         self.derBytes = derBytes
     }
 
-    #if canImport(Foundation)
     /// PEM string is a base 64 encoded string of ``derBytes`` enclosed in BEGIN and END encapsulation boundaries with the specified ``discriminator`` type.
     ///
     /// Example PEM string:
@@ -227,7 +221,6 @@ public struct PEMDocument {
 
         return pemLines.joined(separator: "\n")
     }
-    #endif
 }
 
 extension Substring {
@@ -258,3 +251,5 @@ extension Substring {
         return String(utf8Bytes)
     }
 }
+
+#endif

--- a/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
@@ -50,17 +50,6 @@ public protocol PEMParseable: DERParseable {
     /// ```
     static var defaultPEMDiscriminator: String { get }
     
-    
-    /// The PEM discriminator allowed to be present when parsing a PEM string.
-    ///
-    /// The PEM discriminator is in the first line of a PEM string after `BEGIN` and at the end of the string after `END` e.g.
-    /// ```
-    /// -----BEGIN defaultPEMDiscriminator-----
-    /// <base 64 DER representation of this object>
-    /// -----END defaultPEMDiscriminator-----
-    /// ```
-    static var allowedPEMDiscriminators: Set<String> { get }
-    
     init(pemDocument: PEMDocument) throws
 }
 
@@ -74,23 +63,11 @@ public protocol PEMParseable: DERParseable {
 public typealias PEMRepresentable = PEMSerializable & PEMParseable
 
 extension PEMParseable {
-    /// The PEM discriminator allowed to be present when parsing a PEM string.
-    /// The default implementation just allowed ``defaultPEMDiscriminator`` to be present.
-    ///
-    /// The PEM discriminator is in the first line of a PEM string after `BEGIN` and at the end of the string after `END` e.g.
-    /// ```
-    /// -----BEGIN defaultPEMDiscriminator-----
-    /// <base 64 DER representation of this object>
-    /// -----END defaultPEMDiscriminator-----
-    /// ```
-    @inlinable
-    public static var allowedPEMDiscriminators: Set<String> {
-        Set([defaultPEMDiscriminator])
-    }
     
     /// Initialize this object from a serialized PEM representation.
-    /// This will check that the ``PEMParseable/allowedPEMDiscriminators-2h84f`` matches, decode the base64 encoded string and
-    /// forward the DER encoded bytes to ``DERParseable/init(derEncoded:)-i2rf``.
+    /// 
+    /// This will check that the discriminator matches ``PEMParseable/defaultPEMDiscriminator``, decode the base64 encoded string and
+    /// then decode the DER encoded bytes using ``DERParseable/init(derEncoded:)-i2rf``.
     ///
     /// - parameters:
     ///     - pemEncoded: The PEM-encoded string representing this object.
@@ -107,8 +84,8 @@ extension PEMParseable {
     ///     - pemDocument: DER-encoded PEM document
     @inlinable
     public init(pemDocument: PEMDocument) throws {
-        guard Self.allowedPEMDiscriminators.contains(pemDocument.discriminator) else {
-            throw ASN1Error.invalidPEMDocument(reason: "PEMDocument has incorrect discriminator \(pemDocument.discriminator). Expected \(Self.allowedPEMDiscriminators) instead")
+        guard pemDocument.discriminator == Self.defaultPEMDiscriminator else {
+            throw ASN1Error.invalidPEMDocument(reason: "PEMDocument has incorrect discriminator \(pemDocument.discriminator). Expected \(Self.defaultPEMDiscriminator) instead")
         }
             
         try self.init(derEncoded: pemDocument.derBytes)

--- a/Sources/SwiftASN1/Docs.docc/PEM.md
+++ b/Sources/SwiftASN1/Docs.docc/PEM.md
@@ -4,7 +4,7 @@ Serialize and deserialize objects from PEM format.
 
 ### Parsing an object from a PEM string
 
-Types conforming to the ``PEMParseable`` protocol can be constructed from a PEM string by calling ``PEMParseable/init(pemEncoded:)`` on the specific type. This will check that the discriminator is included in ``PEMParseable/allowedPEMDiscriminators-2h84f``, decode the base64 encoded string and then decode the DER encoded bytes using ``DERParseable/init(derEncoded:)-i2rf``.
+Types conforming to the ``PEMParseable`` protocol can be constructed from a PEM string by calling ``PEMParseable/init(pemEncoded:)`` on the specific type. This will check that the discriminator matches ``PEMParseable/defaultPEMDiscriminator``, decode the base64 encoded string and then decode the DER encoded bytes using ``DERParseable/init(derEncoded:)-i2rf``.
 
 ### Serializing an object as a PEM string
 Types conforming to the ``PEMSerializable`` protocol can be serialized to a PEM document by calling ``PEMSerializable/serializeAsPEM()`` on the specific type. This will encode the object through ``DER/Serializer``, then encode the DER encoded bytes as base64 and use ``PEMSerializable/defaultPEMDiscriminator`` as the discriminator. The PEM string can then be access through ``PEMDocument/pemString`` property on ``PEMDocument``.

--- a/Sources/SwiftASN1/Docs.docc/PEM.md
+++ b/Sources/SwiftASN1/Docs.docc/PEM.md
@@ -1,0 +1,17 @@
+# Parsing and Serializing PEM
+
+Serialize and deserialize objects from PEM format.
+
+### Parsing an object from a PEM string
+
+Types conforming to the ``PEMParseable`` protocol can be constructed from a PEM string by calling ``PEMParseable/init(pemEncoded:)`` on the specific type. This will check that the discriminator is included in ``PEMParseable/allowedPEMDiscriminators-2h84f``, decode the base64 encoded string and then decode the DER encoded bytes using ``DERParseable/init(derEncoded:)-i2rf``.
+
+### Serializing an object as a PEM string
+Types conforming to the ``PEMSerializable`` protocol can be serialized to a PEM document by calling ``PEMSerializable/serializeAsPEM()`` on the specific type. This will encode the object through ``DER/Serializer``, then encode the DER encoded bytes as base64 and use ``PEMSerializable/defaultPEMDiscriminator`` as the discriminator. The PEM string can then be access through ``PEMDocument/pemString`` property on ``PEMDocument``.
+
+### Related Types
+
+- ``PEMDocument``
+- ``PEMRepresentable``
+- ``PEMParseable``
+- ``PEMSerializable``

--- a/Sources/SwiftASN1/Docs.docc/index.md
+++ b/Sources/SwiftASN1/Docs.docc/index.md
@@ -24,6 +24,7 @@ This module provides several moving pieces:
 2. A DER parser that can construct the ASN.1 tree from serialized bytes (``DER/parse(_:)-72yd1``).
 3. A DER serializer that can construct serialized bytes from the ASN.1 tree (``DER/Serializer``).
 4. A number of built-in ASN.1 types, representing common constructs.
+5. A PEM parser and serializer
 
 These moving pieces combine to provide support for the DER representation of ASN.1 suitable for a wide range of cryptographic uses.
 
@@ -32,6 +33,7 @@ These moving pieces combine to provide support for the DER representation of ASN
 ### Articles
 
 - <doc:DecodingASN1>
+- <doc:PEM>
 
 ### Parsing DER
 
@@ -83,3 +85,9 @@ These moving pieces combine to provide support for the DER representation of ASN
 - ``ASN1IA5String``
 - ``ASN1TeletexString``
 - ``ASN1UniversalString``
+
+### Parsing and Serializing PEM
+- ``PEMRepresentable``
+- ``PEMParseable``
+- ``PEMSerializable``
+- ``PEMDocument``

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -423,10 +423,10 @@ O9zxi7HTvuXyQr7QKSBtdCGmHym+WoPsbA==
 -----END EC PRIVATE KEY-----
 """
         let document = try PEMDocument(pemString: simplePEM)
-        XCTAssertEqual(document.type, "EC PRIVATE KEY")
+        XCTAssertEqual(document.discriminator, "EC PRIVATE KEY")
         XCTAssertEqual(document.derBytes.count, 121)
 
-        let parsed = try DER.parse(Array(document.derBytes))
+        let parsed = try DER.parse(document.derBytes)
         let pkey = try SEC1PrivateKey(derEncoded: parsed)
 
         let reserialized = document.pemString
@@ -434,7 +434,7 @@ O9zxi7HTvuXyQr7QKSBtdCGmHym+WoPsbA==
 
         var serializer = DER.Serializer()
         XCTAssertNoThrow(try serializer.serialize(pkey))
-        let reserialized2 = PEMDocument(type: "EC PRIVATE KEY", derBytes: Data(serializer.serializedBytes))
+        let reserialized2 = PEMDocument(type: "EC PRIVATE KEY", derBytes: serializer.serializedBytes)
         XCTAssertEqual(reserialized2.pemString, simplePEM)
     }
     
@@ -448,13 +448,13 @@ O9zxi7HTvuXyQr7QKSBtdCGmHym+WoPsbA==
 """
         let pkey = try SEC1PrivateKey(pemEncoded: simplePEM)
 
-        let reserialized = try PEMSerializer().serialize(pkey)
+        let reserialized = try pkey.serializeAsPEM().pemString
         XCTAssertEqual(reserialized, simplePEM)
 
         var serializer = DER.Serializer()
         XCTAssertNoThrow(try serializer.serialize(pkey))
         let reserialized2 = try SEC1PrivateKey(derEncoded: serializer.serializedBytes)
-        XCTAssertEqual(try PEMSerializer().serialize(reserialized2), simplePEM)
+        XCTAssertEqual(try reserialized2.serializeAsPEM().pemString, simplePEM)
     }
 
     func testTruncatedPEMDocumentsAreRejected() throws {

--- a/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
@@ -22,7 +22,7 @@ import SwiftASN1
 //   publicKey [1] EXPLICIT BIT STRING OPTIONAL
 // }
 struct SEC1PrivateKey: DERImplicitlyTaggable, PEMRepresentable {
-    static let pemDiscriminator: String = "EC PRIVATE KEY"
+    static let defaultPEMDiscriminator: String = "EC PRIVATE KEY"
     
     static var defaultIdentifier: ASN1Identifier {
         return .sequence

--- a/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
@@ -21,7 +21,9 @@ import SwiftASN1
 //   parameters [0] EXPLICIT ECDomainParameters OPTIONAL,
 //   publicKey [1] EXPLICIT BIT STRING OPTIONAL
 // }
-struct SEC1PrivateKey: DERImplicitlyTaggable {
+struct SEC1PrivateKey: DERImplicitlyTaggable, PEMRepresentable {
+    static let pemDiscriminator: String = "EC PRIVATE KEY"
+    
     static var defaultIdentifier: ASN1Identifier {
         return .sequence
     }


### PR DESCRIPTION
This PR adds first class PEM support to `swift-asn1`.

Users can add PEM support to their `DERSerializable` and `DERParseable` types by conforming to the `PEMSerializable` and `PEMParseable` protocol respectively. To conform to these protocols they just need to add a `static let pemDiscriminator: String`. This is the name found after `BEGIN` at the start of a PEM document and after `END` at the end e.g.:
```
-----BEGIN pemDiscrimiator-----
<base 64 DER representation of this object>
-----END pemDiscrimiator-----
```

Afterwards `PEMParseable` automatically provides an `init(pemEncoded: String)` to initialise an object from a PEM document. Types conforming to `PEMSerializable ` can be used with `PEMSerializer` to serialise an object as a PEM string by calling `PEMSerializer.serialize(_:)`. 

`PEMRepresentable` is a typealias for `PEMSerializable & PEMParseable` for the most common case where a type can be serialised and parsed from a PEM document.

This PR also includes an alternative `pemString: String` accessor to the `PEMSerializer`. However, I think we should go with `PEMSerializer` to add support for more advanced use cases in the future. I will remove the duplicate code once we have settled on one or the other option.