### PR TITLE
Clean up the upToNextMinor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use swift-asn1, add the following dependency to your Package.swift:
 
  ```swift
  dependencies: [
-     .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.7.0"))
+     .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.8.0"))
  ]
  ```
 


### PR DESCRIPTION
Minor cleanup in the `upToNextMinor` code in the README.