### PR TITLE
Fix bug in comparing Generalized and UTC Time

### DIFF
--- a/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
@@ -200,12 +200,12 @@ public struct GeneralizedTime: DERImplicitlyTaggable, Hashable, Sendable {
 extension GeneralizedTime: Comparable {
     @inlinable
     public static func <(lhs: GeneralizedTime, rhs: GeneralizedTime) -> Bool {
-        if lhs.year < rhs.year { return true }
-        if lhs.month < rhs.month { return true }
-        if lhs.day < rhs.day { return true }
-        if lhs.hours < rhs.hours { return true }
-        if lhs.minutes < rhs.minutes { return true }
-        if lhs.seconds < rhs.seconds { return true }
+        if lhs.year < rhs.year { return true } else if lhs.year > rhs.year { return false }
+        if lhs.month < rhs.month { return true } else if lhs.month > rhs.month { return false }
+        if lhs.day < rhs.day { return true } else if lhs.day > rhs.day { return false }
+        if lhs.hours < rhs.hours { return true } else if lhs.hours > rhs.hours { return false }
+        if lhs.minutes < rhs.minutes { return true } else if lhs.minutes > rhs.minutes { return false }
+        if lhs.seconds < rhs.seconds { return true } else if lhs.seconds > rhs.seconds { return false }
         return lhs.fractionalSeconds < rhs.fractionalSeconds
     }
 }

--- a/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
@@ -184,11 +184,11 @@ public struct UTCTime: DERImplicitlyTaggable, Hashable, Sendable {
 extension UTCTime: Comparable {
     @inlinable
     public static func <(lhs: UTCTime, rhs: UTCTime) -> Bool {
-        if lhs.year < rhs.year { return true }
-        if lhs.month < rhs.month { return true }
-        if lhs.day < rhs.day { return true }
-        if lhs.hours < rhs.hours { return true }
-        if lhs.minutes < rhs.minutes { return true }
+        if lhs.year < rhs.year { return true } else if lhs.year > rhs.year { return false }
+        if lhs.month < rhs.month { return true } else if lhs.month > rhs.month { return false }
+        if lhs.day < rhs.day { return true } else if lhs.day > rhs.day { return false }
+        if lhs.hours < rhs.hours { return true } else if lhs.hours > rhs.hours { return false }
+        if lhs.minutes < rhs.minutes { return true } else if lhs.minutes > rhs.minutes { return false }
         return lhs.seconds < rhs.seconds
     }
 }

--- a/Tests/SwiftASN1Tests/GeneralizedTimeTests.swift
+++ b/Tests/SwiftASN1Tests/GeneralizedTimeTests.swift
@@ -208,6 +208,11 @@ final class GeneralizedTimeTests: XCTestCase {
         transformationsAndResults.append((modify(\.fractionalSeconds, of: original, by: 0.1), .greaterThan))
         transformationsAndResults.append((modify(\.fractionalSeconds, of: original, by: -0.1), .lessThan))
 
+        transformationsAndResults.append((
+            try GeneralizedTime(year: 2019, month: 08, day: 08, hours: 08, minutes: 08, seconds: 08, fractionalSeconds: 0.205),
+            .lessThan
+        ))
+
         for (newValue, expectedResult) in transformationsAndResults {
             switch expectedResult {
             case .lessThan:

--- a/Tests/SwiftASN1Tests/UTCTimeTests.swift
+++ b/Tests/SwiftASN1Tests/UTCTimeTests.swift
@@ -43,6 +43,11 @@ final class UTCTimeTests: XCTestCase {
             transformationsAndResults.append((modify(transform, of: original, by: -1), .lessThan))
         }
 
+        transformationsAndResults.append((
+            try UTCTime(year: 2019, month: 08, day: 08, hours: 08, minutes: 08, seconds: 08),
+            .lessThan
+        ))
+
         for (newValue, expectedResult) in transformationsAndResults {
             switch expectedResult {
             case .lessThan:


### PR DESCRIPTION
The prior time comparison did not correctly handle wildly different times. This patch resolves the issue.