### PR TITLE
Avoid using stride(from:to:by:).reversed()

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -1254,12 +1254,17 @@ extension FixedWidthInteger {
         }
 
         self = 0
-        let shiftSizes = stride(from: 0, to: bytes.count * 8, by: 8).reversed()
+
+        // Unchecked subtraction because bytes.count must be positive, so we can safely subtract 8 after the
+        // multiply. The same logic applies to the math in the loop. Finally, the multiply can be unchecked because
+        // we know that bytes.count is less than or equal to bitWidth / 8, so multiplying by 8 cannot possibly overflow.
+        var shift = (bytes.count &* 8) &- 8
 
         var index = bytes.startIndex
-        for shift in shiftSizes {
+        while shift >= 0 {
             self |= Self(truncatingIfNeeded: bytes[index]) << shift
             bytes.formIndex(after: &index)
+            shift &-= 8
         }
     }
 }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -306,12 +306,17 @@ extension UInt {
         }
 
         self = 0
-        let shiftSizes = stride(from: 0, to: bytes.count * 7, by: 7).reversed()
+
+        // Unchecked subtraction because bytes.count must be positive, so we can safely subtract 7 after the
+        // multiply. The same logic applies to the math in the loop. Finally, the multiply can be unchecked because
+        // we already did it above and we didn't overflow there.
+        var shift = (bytes.count &* 7) &- 7
 
         var index = bytes.startIndex
-        for shift in shiftSizes {
+        while shift >= 0 {
             self |= UInt(bytes[index] & 0x7F) << shift
             bytes.formIndex(after: &index)
+            shift &-= 7
         }
     }
 }


### PR DESCRIPTION
While this is a nice clear construction, it also has to allocate a temporary Array, as the StrideTo type is not a BidirectionalCollection but a Sequence.