### PR TITLE
Make `IntegerBytesCollection` conditionally `Sendable`

### DIFF
--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
@@ -130,7 +130,7 @@ extension ASN1IntegerRepresentable where Self: FixedWidthInteger {
 }
 
 /// A big-endian `Collection` of bytes representing a fixed width integer.
-public struct IntegerBytesCollection<Integer: FixedWidthInteger & Sendable> {
+public struct IntegerBytesCollection<Integer: FixedWidthInteger> {
     @usableFromInline var integer: Integer
 
     /// Construct an ``IntegerBytesCollection`` representing the bytes of this integer.
@@ -142,7 +142,7 @@ public struct IntegerBytesCollection<Integer: FixedWidthInteger & Sendable> {
 
 extension IntegerBytesCollection: Hashable { }
 
-extension IntegerBytesCollection: Sendable { }
+extension IntegerBytesCollection: Sendable where Integer: Sendable {}
 
 extension IntegerBytesCollection: RandomAccessCollection {
     public struct Index {


### PR DESCRIPTION
Otherwise we get `Sendable` warnings in `swift-certifcates` because we do not want to add a Sendable requirement on this `init`:
```swift
extension Certificate.SerialNumber {
    init(_ integer: some FixedWidthInteger) {
        self.bytes = ArraySlice(IntegerBytesCollection(integer))
    }
}
```