### PR TITLE
Support macOS 10.14.x/iOS 12.x and older again

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -183,15 +183,7 @@ extension DER {
     /// - returns: An array of elements representing the elements in the sequence.
     @inlinable
     public static func set<T: DERParseable>(of type: T.Type = T.self, identifier: ASN1Identifier, rootNode: ASN1Node) throws -> [T] {
-        guard rootNode.identifier == identifier, case .constructed(let nodes) = rootNode.content else {
-            throw ASN1Error.unexpectedFieldType(rootNode.identifier)
-        }
-        
-        guard nodes.isOrderedAccordingToSetOfSemantics() else {
-            throw ASN1Error.invalidASN1Object(reason: "SET OF fields are not lexicographically ordered")
-        }
-        
-        return try nodes.map { node in try T(derEncoded: node) }
+        try self.lazySet(of: type, identifier: identifier, rootNode: rootNode).map { try $0.get() }
     }
     
     /// Parse the node as an ASN.1 SET OF lazily.
@@ -204,7 +196,6 @@ extension DER {
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: A `Sequence` of elements representing the `Result` of parsing the elements in the sequence.
     @inlinable
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public static func lazySet<T: DERParseable>(of: T.Type = T.self, identifier: ASN1Identifier, rootNode: ASN1Node) throws -> some Sequence<Result<T, Error>> {
         guard rootNode.identifier == identifier, case .constructed(let nodes) = rootNode.content else {
             throw ASN1Error.unexpectedFieldType(rootNode.identifier)

--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -183,7 +183,15 @@ extension DER {
     /// - returns: An array of elements representing the elements in the sequence.
     @inlinable
     public static func set<T: DERParseable>(of type: T.Type = T.self, identifier: ASN1Identifier, rootNode: ASN1Node) throws -> [T] {
-        try self.lazySet(of: type, identifier: identifier, rootNode: rootNode).map { try $0.get() }
+        guard rootNode.identifier == identifier, case .constructed(let nodes) = rootNode.content else {
+            throw ASN1Error.unexpectedFieldType(rootNode.identifier)
+        }
+        
+        guard nodes.isOrderedAccordingToSetOfSemantics() else {
+            throw ASN1Error.invalidASN1Object(reason: "SET OF fields are not lexicographically ordered")
+        }
+        
+        return try nodes.map { node in try T(derEncoded: node) }
     }
     
     /// Parse the node as an ASN.1 SET OF lazily.
@@ -196,6 +204,7 @@ extension DER {
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: A `Sequence` of elements representing the `Result` of parsing the elements in the sequence.
     @inlinable
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public static func lazySet<T: DERParseable>(of: T.Type = T.self, identifier: ASN1Identifier, rootNode: ASN1Node) throws -> some Sequence<Result<T, Error>> {
         guard rootNode.identifier == identifier, case .constructed(let nodes) = rootNode.content else {
             throw ASN1Error.unexpectedFieldType(rootNode.identifier)

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -867,9 +867,6 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
         XCTAssertEqual(bitStrings, [
             ASN1BitString(bytes: [1]),
         ])
-        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
-        }
     }
     
     func testSetOfTwoElementsInOrder() throws {
@@ -885,9 +882,6 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [2]),
         ])
-        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
-        }
     }
     
     func testSetOfTwoElementNotInOrder() throws {
@@ -903,9 +897,6 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [2]),
         ])
-        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
-        }
     }
     func testSetOfTwoEqualElements() throws {
         var serializer = DER.Serializer()
@@ -920,19 +911,11 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [1]),
         ])
-        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
-        }
     }
     func testSetOfTwoElementsOrderedIncorrectly() throws {
         let rootNode = try DER.parse([49, 8, 3, 2, 0, 2, 3, 2, 0, 1])
         XCTAssertThrowsError(try DER.set(of: ASN1BitString.self, identifier: .set, rootNode: rootNode)) { error in
             XCTAssertEqual((error as? ASN1Error)?.code, .invalidASN1Object)
-        }
-        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
-            XCTAssertThrowsError(try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: rootNode)) { error in
-                XCTAssertEqual((error as? ASN1Error)?.code, .invalidASN1Object)
-            }
         }
     }
     

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -867,6 +867,9 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
         XCTAssertEqual(bitStrings, [
             ASN1BitString(bytes: [1]),
         ])
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
+        }
     }
     
     func testSetOfTwoElementsInOrder() throws {
@@ -882,6 +885,9 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [2]),
         ])
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
+        }
     }
     
     func testSetOfTwoElementNotInOrder() throws {
@@ -897,6 +903,9 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [2]),
         ])
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
+        }
     }
     func testSetOfTwoEqualElements() throws {
         var serializer = DER.Serializer()
@@ -911,11 +920,19 @@ O9zxi7HTvuXyQr7QKSBtdC%mHym+WoPsbA==
             ASN1BitString(bytes: [1]),
             ASN1BitString(bytes: [1]),
         ])
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertEqual(bitStrings, try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: try DER.parse(serializer.serializedBytes)).map { try $0.get() })
+        }
     }
     func testSetOfTwoElementsOrderedIncorrectly() throws {
         let rootNode = try DER.parse([49, 8, 3, 2, 0, 2, 3, 2, 0, 1])
         XCTAssertThrowsError(try DER.set(of: ASN1BitString.self, identifier: .set, rootNode: rootNode)) { error in
             XCTAssertEqual((error as? ASN1Error)?.code, .invalidASN1Object)
+        }
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+            XCTAssertThrowsError(try DER.lazySet(of: ASN1BitString.self, identifier: .set, rootNode: rootNode)) { error in
+                XCTAssertEqual((error as? ASN1Error)?.code, .invalidASN1Object)
+            }
         }
     }
     


### PR DESCRIPTION
### Motivation
#32 has broken older platforms accidentally.

### Modifications
- add availability annotations to `DER.lazySet` 
- copy over the implementation of `DER.lazySet` to `DER.set`
- add tests specifically covering `DER.lazySet` because we can no longer use `DER.lazySet` in the implementation of `DER.set` and therefore `DER.lazySet` would be completely untested.

### Result
We again support macOS 10.14.x/iOS 12.x and older.