### PR TITLE
Add CI pipeline for Swift 5.10

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -3,18 +3,17 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-asn1:22.04-5.9
+    image: swift-asn1:22.04-5.10
     build:
       args:
-        ubuntu_version: "jammy"
-        swift_version: "5.9"
+        base_image: "swiftlang/swift:nightly-5.10-jammy"
 
   test:
-    image: swift-asn1:22.04-5.9
+    image: swift-asn1:22.04-5.10
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:
-    image: swift-asn1:22.04-5.9
+    image: swift-asn1:22.04-5.10


### PR DESCRIPTION
Motivation:

Now that Swift 5.9 is GM we should update the CI pipelines

Modifications:

* Add a 5.10 nightly docker compose file
* Update the 5.9 compose file to stop using nightlies

Result:

Remove add CI support for 5.10