### PR TITLE
Remove note from README about API instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,9 @@ To use swift-asn1, add the following dependency to your Package.swift:
 
  ```swift
  dependencies: [
-     .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.8.0"))
+     .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMajor(from: "1.0.0"))
  ]
  ```
-
- Note that this repository does not have a 1.0 tag yet, so the API is not stable.
 
  You can then add the specific product dependency to your target:
 


### PR DESCRIPTION
I think we can remove that note now that the library has 1.0.0 tag.