### PR TITLE
Swift 6 preparedness

### DIFF
--- a/Benchmarks/Benchmarks/SwiftASN1Benchmark/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/SwiftASN1Benchmark/Benchmarks.swift
@@ -23,8 +23,6 @@ let benchmarks = {
             .readSyscalls,
             .writeSyscalls,
             .memoryLeaked,
-            .retainCount,
-            .releaseCount,
         ]
     )
 

--- a/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 13983,
-  "retainCount" : 12200,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -1,5 +1,5 @@
 {
-  "mallocCountTotal" : 960,
+  "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
   "releaseCount" : 13983,

--- a/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
+++ b/Benchmarks/Thresholds/5.10/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 967,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 12900,
-  "retainCount" : 11382,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 17688,
-  "retainCount" : 15905,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -1,5 +1,5 @@
 {
-  "mallocCountTotal" : 960,
+  "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
   "releaseCount" : 17688,

--- a/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
+++ b/Benchmarks/Thresholds/5.8/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 967,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 16605,
-  "retainCount" : 15087,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -1,5 +1,5 @@
 {
-  "mallocCountTotal" : 960,
+  "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
   "releaseCount" : 13846,

--- a/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 13846,
-  "retainCount" : 12063,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
+++ b/Benchmarks/Thresholds/5.9/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 967,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 12763,
-  "retainCount" : 11245,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 13983,
-  "retainCount" : 12200,
   "writeSyscalls" : 0
 }

--- a/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -1,5 +1,5 @@
 {
-  "mallocCountTotal" : 960,
+  "mallocCountTotal" : 976,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
   "releaseCount" : 13983,

--- a/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
+++ b/Benchmarks/Thresholds/main/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
@@ -2,7 +2,5 @@
   "mallocCountTotal" : 967,
   "memoryLeaked" : 0,
   "readSyscalls" : 0,
-  "releaseCount" : 12900,
-  "retainCount" : 11382,
   "writeSyscalls" : 0
 }

--- a/docker/docker-compose.2204.60.yaml
+++ b/docker/docker-compose.2204.60.yaml
@@ -3,15 +3,15 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-asn1:22.04-main
+    image: swift-asn1:22.04-6.0
     build:
       args:
-        base_image: "swiftlang/swift:nightly-main-jammy"
+        base_image: "swiftlang/swift:nightly-6.0-jammy"
 
   test:
-    image: swift-asn1:22.04-main
+    image: swift-asn1:22.04-6.0
     environment:
-      - SWIFT_VERSION=main
+      - SWIFT_VERSION=6.0
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - EXPLICIT_SENDABLE_ARG=-Xswiftc -require-explicit-sendable
@@ -19,9 +19,10 @@ services:
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:
-    image: swift-asn1:22.04-main
-    
+    image: swift-asn1:22.04-6.0
+
   update-benchmark-baseline:
-    image: swift-asn1:22.04-main
+    image: swift-asn1:22.04-6.0
     environment:
-      - SWIFT_VERSION=main
+      - SWIFT_VERSION=6.0
+

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} && cd Benchmarks && swift package benchmark baseline check --check-absolute-path Thresholds/$${SWIFT_VERSION-}/"
+    command: /bin/bash -xcl "swift $${SWIFT_TEST_VERB-test} $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG} && cd Benchmarks && swift package benchmark baseline check --check-absolute-path Thresholds/$${SWIFT_VERSION-}/"
 
   update-benchmark-baseline:
     <<: *common
@@ -36,3 +36,4 @@ services:
   shell:
     <<: *common
     entrypoint: /bin/bash
+


### PR DESCRIPTION
Motivation

We should feel confident that we compile clean under the strict checks of Swift 6. As this is a data-processing-only framework it's not a surprise that it turns out to be fine, but this patch adds the necessary docker-compose steps to ensure it continues to work.

Modifications

- Add docker-compose file for Swift 6 nightlies
- Extend docker-compose to pass explicit sendable and strict concurrency checks
- Add those checks to 6.0 and main nightlies

Result

Better confidence that we don't break our downstreams in Swift 6 support.