### PR TITLE
Correct the link of sswg-security at SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,6 @@ with all the required detail.
   forums][swift-forums-sec].
 
 [sswg]: https://github.com/swift-server/sswg
-[sswg-security]: https://github.com/swift-server/sswg/blob/main/process/incubation.md#security-best-practices
+[sswg-security]: https://www.swift.org/sswg/security/
 [swift-forums-sec]: https://forums.swift.org/c/server/security-updates/
 [mitre]: https://cveform.mitre.org/


### PR DESCRIPTION
### Motivation:
Correct the link of sswg-security at SECURITY.md. Currently it is showing "Not Found".

### Modifications:
+ https://github.com/swift-server/sswg/blob/main/process/incubation.md#security-best-practices => https://www.swift.org/sswg/security/

### Result:
Correct the link of sswg-security