### PR TITLE
Update code to compile without issue when ExistentialAny enabled

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -268,10 +268,10 @@ extension ASN1.ParseResult: Hashable {}
 // MARK: - LazySetOfSequence
 extension ASN1 {
     public struct LazySetOfSequence<T>: Sequence {
-        public typealias Element = Result<T, Error>
+        public typealias Element = Result<T, any Error>
 
         @usableFromInline
-        typealias WrappedSequence = LazyMapSequence<LazySequence<(ASN1NodeCollection)>.Elements, Result<T, Error>>
+        typealias WrappedSequence = LazyMapSequence<LazySequence<(ASN1NodeCollection)>.Elements, Result<T, any Error>>
 
         public struct Iterator: IteratorProtocol {
             @usableFromInline


### PR DESCRIPTION
Motivation:

We should feel confident that we compile clean when built in an environment that has enabled upcoming Swift features.

When compiling swift-asn1 specifying `.enableUpcomingFeature("ExistentialAny")` there are some minor warnings emitted by ASN1.swift.

Modifications:

Minor code changes to address surfaced warnings

Result:

Better confidence that we don't break downstreams that compile this code with these upcoming features enabled.