### PR TITLE
Update link for swift-docc-plugin repository moved to the swiftlang org on GitHub

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,6 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     ]
 }


### PR DESCRIPTION
###Summary:
Update link for swift-docc-plugin repository moved to the swiftlang org on GitHub

###Modifications:
Update the link:
+ https://github.com/apple/swift-docc-plugin => https://github.com/swiftlang/swift-docc-plugin

###Result:
Correct the link:
+ https://github.com/apple/swift-docc-plugin => https://github.com/swiftlang/swift-docc-plugin