### PR TITLE
Update Swift targets to enable ExistentialAny

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+let upcomingFeatureSwiftSettings: [SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny"),
+]
+
 let package = Package(
     name: "swift-asn1",
     products: [
@@ -24,9 +28,14 @@ let package = Package(
     targets: [
         .target(
             name: "SwiftASN1",
-            exclude: ["CMakeLists.txt"]
+            exclude: ["CMakeLists.txt"],
+            swiftSettings: upcomingFeatureSwiftSettings
         ),
-        .testTarget(name: "SwiftASN1Tests", dependencies: ["SwiftASN1"]),
+        .testTarget(
+            name: "SwiftASN1Tests",
+            dependencies: ["SwiftASN1"],
+            swiftSettings: upcomingFeatureSwiftSettings
+        )
     ]
 )
 


### PR DESCRIPTION
Motivation:

With the advent of Upcoming Feature Flags https://www.swift.org/blog/using-upcoming-feature-flags/ , we should make it a one-liner to enable feature flags.

As a follow-on to PR 63, we should enable the ExistentialAny feature flag, as the code currently complies, and we may as well help flag any unintentional regressions to that behavior.

Modifications:

Update Package.swift to allow for one-liner additions of new feature flags. Enable the upcoming feature flag ExistentialAny

Result:

Better confidence that we don't break downstreams that compile this code with ExistentialAny enabled.
Makes it (slightly) easier for future authors to modify the set of enabled feature flags.