### PR TITLE
More Sendability annotiations

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -12,12 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+
+@available(*, unavailable)
+extension ASN1: Sendable { }
+
 public enum ASN1 {}
 
 // MARK: - EncodingRules
 extension ASN1 {
     @usableFromInline
-    enum EncodingRules {
+    enum EncodingRules: Sendable {
         case basic
 
         case distinguished
@@ -124,7 +128,7 @@ extension ASN1.ParserNode {
 
 extension ASN1 {
     @usableFromInline
-    struct ParseResult {
+    struct ParseResult: Sendable {
         @inlinable
         static var _maximumNodeDepth: Int { 50 }
 
@@ -303,6 +307,12 @@ extension ASN1 {
     }
 }
 
+@available(*, unavailable)
+extension ASN1.LazySetOfSequence: Sendable {}
+
+@available(*, unavailable)
+extension ASN1.LazySetOfSequence.Iterator: Sendable {}
+
 // MARK: - NodeCollection
 /// Represents a collection of ASN.1 nodes contained in a constructed ASN.1 node.
 ///
@@ -333,7 +343,7 @@ extension ASN1NodeCollection: Sendable {}
 
 extension ASN1NodeCollection: Sequence {
     /// An iterator of ASN.1 nodes that are children of a specific constructed node.
-    public struct Iterator: IteratorProtocol {
+    public struct Iterator: IteratorProtocol, Sendable {
         @usableFromInline
         var _nodes: ArraySlice<ASN1.ParserNode>
 
@@ -427,7 +437,7 @@ extension ASN1Node {
 
 extension ArraySlice where Element == UInt8 {
     @usableFromInline
-    enum ASN1Length {
+    enum ASN1Length: Sendable {
         case indefinite
         case definite(_: UInt)
     }

--- a/Sources/SwiftASN1/BER.swift
+++ b/Sources/SwiftASN1/BER.swift
@@ -16,6 +16,9 @@
 /// for BER encoding and decoding.
 public enum BER {}
 
+@available(*, unavailable)
+extension BER: Sendable {}
+
 // MARK: - Parser Node
 extension BER {
     @usableFromInline

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -217,6 +217,18 @@ extension ASN1ObjectIdentifier: CustomStringConvertible {
     }
 }
 
+@available(*, unavailable)
+extension ASN1ObjectIdentifier.NamedCurves: Sendable {}
+
+@available(*, unavailable)
+extension ASN1ObjectIdentifier.AlgorithmIdentifier: Sendable {}
+
+@available(*, unavailable)
+extension ASN1ObjectIdentifier.NameAttributes: Sendable {}
+
+@available(*, unavailable)
+extension ASN1ObjectIdentifier.OCSP: Sendable {}
+
 extension ASN1ObjectIdentifier {
     /// Represents a namespace for OIDs that identify named Elliptic Curves.
     ///

--- a/Sources/SwiftASN1/Basic ASN1 Types/TimeUtilities.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/TimeUtilities.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+
+@available(*, unavailable)
+extension TimeUtilities: Sendable {}
+
 @usableFromInline
 enum TimeUtilities {
     @inlinable

--- a/Sources/SwiftASN1/DER.swift
+++ b/Sources/SwiftASN1/DER.swift
@@ -16,6 +16,9 @@
 /// for DER encoding and decoding.
 public enum DER {}
 
+@available(*, unavailable)
+extension DER: Sendable {}
+
 // MARK: - Parser Node
 extension DER {
     @usableFromInline


### PR DESCRIPTION
Motivation:

Completing annotations helps with coverage for consuming projects.

Modifications:

Mark more things and Sendable or not.

Result:

Consuming libraries more likely to get correct usage.