### PR TITLE
CI: concurrency=complete require-explicit-sendable

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,9 +16,9 @@ jobs:
         with:
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
     benchmarks:
         name: Benchmarks

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,8 +16,9 @@ jobs:
         with:
             linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
 
     benchmarks:
         name: Benchmarks

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -10,8 +10,8 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_8_enabled: false
-            linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,5 +12,6 @@ jobs:
             linux_5_8_enabled: false
             linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable"

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ import PackageDescription
 import class Foundation.ProcessInfo
 
 let upcomingFeatureSwiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny")
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("StrictConcurrency"),
 ]
 
 let package = Package(


### PR DESCRIPTION
### Motivation:

Adopt `-Xswiftc -strict-concurrency=complete -Xswiftc -require-explicit-sendable` in CI to lock-in concurrency-safety wins.

### Modifications:

Added strict flags to pull request and scheduled GHA CI on Swift 6.0. Add `StrictConcurrency` to `Package.swift`.

### Result:

CI should ensure we don't regress data-race safety on Swift 6.0.