### PR TITLE
Fix problems preventing xcodebuild with BUILD_LIBRARY_FOR_DISTRIBUTIO…

### DIFF
--- a/Sources/SwiftASN1/BER.swift
+++ b/Sources/SwiftASN1/BER.swift
@@ -21,7 +21,6 @@ extension BER: Sendable {}
 
 // MARK: - Parser Node
 extension BER {
-    @usableFromInline
     typealias ParserNode = ASN1.ParserNode
     typealias ParseResult = ASN1.ParseResult
 }
@@ -29,12 +28,10 @@ extension BER {
 // MARK: - Parsing
 
 extension BER {
-    @inlinable
     public static func parse(_ data: [UInt8]) throws -> ASN1Node {
         return try parse(data[...])
     }
 
-    @inlinable
     public static func parse(_ data: ArraySlice<UInt8>) throws -> ASN1Node {
         var result = try ASN1.ParseResult.parse(data, encoding: .basic)
 
@@ -75,7 +72,6 @@ extension BER {
     ///     - node: The ``ASN1Node`` to parse
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE is expected to have.
     ///     - builder: A closure that will be called with the collection of nodes within the sequence.
-    @inlinable
     public static func sequence<T>(
         _ node: ASN1Node,
         identifier: ASN1Identifier,
@@ -93,7 +89,6 @@ extension BER {
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func sequence<T: BERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -115,7 +110,6 @@ extension BER {
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE OF is expected to have.
     ///     - nodes: An ``ASN1NodeCollection/Iterator`` of nodes to parse.
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func sequence<T: BERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -139,7 +133,6 @@ extension BER {
     ///     - node: The ``ASN1Node`` to parse
     ///     - identifier: The ``ASN1Identifier`` that the SET is expected to have.
     ///     - builder: A closure that will be called with the collection of nodes within the set.
-    @inlinable
     public static func set<T>(
         _ node: ASN1Node,
         identifier: ASN1Identifier,
@@ -158,7 +151,6 @@ extension BER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - nodes: An ``ASN1NodeCollection/Iterator`` of nodes to parse.
     /// - returns: An array of elements representing the elements in the set.
-    @inlinable
     public static func set<T: BERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -183,7 +175,6 @@ extension BER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func set<T: BERParseable>(
         of type: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -201,7 +192,6 @@ extension BER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: A `Sequence` of elements representing the `Result` of parsing the elements in the sequence.
-    @inlinable
     public static func lazySet<T: BERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -233,7 +223,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The result of `builder` if the element was present, or `nil` if it was not.
-    @inlinable
     public static func optionalExplicitlyTagged<T>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -253,7 +242,6 @@ extension BER {
     ///     - tag: The implicit tag. Defaults to the default tag for the element.
     ///
     /// - returns: The parsed element, if it was present, or `nil` if it was not.
-    @inlinable
     public static func optionalImplicitlyTagged<T: DERImplicitlyTaggable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tag: ASN1Identifier = T.defaultIdentifier
@@ -282,7 +270,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The result of `builder` if the element was present, or `nil` if it was not.
-    @inlinable
     public static func optionalImplicitlyTagged<Result>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -306,7 +293,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: BERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         identifier: ASN1Identifier,
@@ -347,7 +333,6 @@ extension BER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: BERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         identifier: ASN1Identifier,
@@ -369,7 +354,6 @@ extension BER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: BERImplicitlyTaggable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         defaultValue: T
@@ -389,7 +373,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefaultExplicitlyTagged<T: BERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -418,7 +401,6 @@ extension BER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefaultExplicitlyTagged<T: BERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -447,7 +429,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element.
     ///
     /// - returns: The result of `builder`.
-    @inlinable
     public static func explicitlyTagged<T>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -466,7 +447,6 @@ extension BER {
     ///     - builder: A closure that will be called with the node for the element.
     ///
     /// - returns: The result of `builder`.
-    @inlinable
     public static func explicitlyTagged<T>(
         _ node: ASN1Node,
         tagNumber: UInt,
@@ -518,12 +498,10 @@ public protocol BERParseable: DERParseable {
 extension BERParseable {
 
     /// By default, uses the underlying DERParseable initializer.
-    @inlinable
     public init(berEncoded node: ASN1Node) throws {
         self = try .init(derEncoded: node)
     }
 
-    @inlinable
     public init(berEncoded sequenceNodeIterator: inout ASN1NodeCollection.Iterator) throws {
         guard let node = sequenceNodeIterator.next() else {
             throw ASN1Error.invalidASN1Object(reason: "Unable to decode \(Self.self), no ASN.1 nodes to decode")
@@ -536,7 +514,6 @@ extension BERParseable {
     ///
     /// - parameters:
     ///     - berEncoded: The BER-encoded bytes representing this object.
-    @inlinable
     public init(berEncoded: [UInt8]) throws {
         self = try .init(berEncoded: BER.parse(berEncoded))
     }
@@ -545,7 +522,6 @@ extension BERParseable {
     ///
     /// - parameters:
     ///     - berEncoded: The BER-encoded bytes representing this object.
-    @inlinable
     public init(berEncoded: ArraySlice<UInt8>) throws {
         self = try .init(berEncoded: BER.parse(berEncoded))
     }
@@ -591,7 +567,6 @@ extension BERImplicitlyTaggable {
     ///     - sequenceNodeIterator: The sequence of nodes that make up this object's parent. The first node in this collection
     ///         will be used to construct this object.
     ///     - identifier: The ASN.1 identifier that `berEncoded` is expected to have.
-    @inlinable
     public init(
         berEncoded sequenceNodeIterator: inout ASN1NodeCollection.Iterator,
         withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier
@@ -608,7 +583,6 @@ extension BERImplicitlyTaggable {
     /// - parameters:
     ///     - berEncoded: The BER-encoded bytes representing this object.
     ///     - identifier: The ASN.1 identifier that `berEncoded` is expected to have.
-    @inlinable
     public init(berEncoded: [UInt8], withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier) throws {
         self = try .init(berEncoded: BER.parse(berEncoded), withIdentifier: identifier)
     }
@@ -618,7 +592,6 @@ extension BERImplicitlyTaggable {
     /// - parameters:
     ///     - berEncoded: The DER-encoded bytes representing this object.
     ///     - identifier: The ASN.1 identifier that `berEncoded` is expected to have.
-    @inlinable
     public init(
         berEncoded: ArraySlice<UInt8>,
         withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier
@@ -630,7 +603,6 @@ extension BERImplicitlyTaggable {
     ///
     /// - parameters:
     ///     - berEncoded: The BER-encoded bytes representing this object.
-    @inlinable
     public init(berEncoded: ASN1Node) throws {
         try self.init(berEncoded: berEncoded, withIdentifier: Self.defaultIdentifier)
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
@@ -20,14 +20,12 @@
 /// The only things users can do with ASN.1 ANYs is to try to decode them as something else,
 /// to create them from something else, or to serialize them.
 public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializable, Hashable, Sendable {
-    @usableFromInline
-    var _serializedBytes: ArraySlice<UInt8>
+    let _serializedBytes: ArraySlice<UInt8>
 
     /// Create an ``ASN1Any`` from a serializable ASN1 type.
     ///
     /// - parameters:
     ///     erasing: The type to be represented as an ASN1 ANY.
-    @inlinable
     public init<ASN1Type: DERSerializable>(erasing: ASN1Type) throws {
         var serializer = DER.Serializer()
         try erasing.serialize(into: &serializer)
@@ -39,14 +37,12 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
     /// - parameters:
     ///     erasing: The type to be represented as an ASN1 ANY.
     ///     identifier: The tag to use with this node.
-    @inlinable
     public init<ASN1Type: DERImplicitlyTaggable>(erasing: ASN1Type, withIdentifier identifier: ASN1Identifier) throws {
         var serializer = DER.Serializer()
         try erasing.serialize(into: &serializer, withIdentifier: identifier)
         self._serializedBytes = ArraySlice(serializer._serializedBytes)
     }
 
-    @inlinable
     public init(derEncoded rootNode: ASN1Node) {
         // This is a bit sad: we just re-serialize this data. In an ideal world
         // we'd update the parse representation so that all nodes can point at their
@@ -56,12 +52,10 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
         self._serializedBytes = ArraySlice(serializer._serializedBytes)
     }
 
-    @inlinable
     public init(berEncoded rootNode: ASN1Node) {
         self = .init(derEncoded: rootNode)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer) throws {
         // Dangerous to just reach in there like this, but it's the right way to serialize this.
         coder.serializeRawBytes(self._serializedBytes)
@@ -69,7 +63,6 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
 }
 
 extension ASN1Any: CustomStringConvertible {
-    @inlinable
     public var description: String {
         "ASN1Any(\(self._serializedBytes))"
     }
@@ -83,7 +76,6 @@ extension DERParseable {
     ///
     /// - parameters:
     ///     asn1Any: The ASN.1 ANY object to reinterpret.
-    @inlinable
     public init(asn1Any: ASN1Any) throws {
         try self.init(derEncoded: asn1Any._serializedBytes)
     }
@@ -98,7 +90,6 @@ extension DERImplicitlyTaggable {
     /// - parameters:
     ///     asn1Any: The ASN.1 ANY object to reinterpret.
     ///     identifier: The tag to use with this node.
-    @inlinable
     public init(asn1Any: ASN1Any, withIdentifier identifier: ASN1Identifier) throws {
         try self.init(derEncoded: asn1Any._serializedBytes, withIdentifier: identifier)
     }
@@ -112,7 +103,6 @@ extension BERParseable {
     ///
     /// - parameters:
     ///     berASN1Any: The ASN.1 ANY object to reinterpret.
-    @inlinable
     public init(berASN1Any: ASN1Any) throws {
         try self.init(berEncoded: berASN1Any._serializedBytes)
     }
@@ -127,7 +117,6 @@ extension BERImplicitlyTaggable {
     /// - parameters:
     ///     berASN1Any: The ASN.1 ANY object to reinterpret.
     ///     identifier: The tag to use with this node.
-    @inlinable
     public init(berASN1Any: ASN1Any, withIdentifier identifier: ASN1Identifier) throws {
         try self.init(berEncoded: berASN1Any._serializedBytes, withIdentifier: identifier)
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1BitString.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1BitString.swift
@@ -24,7 +24,6 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     /// The default identifier for this type.
     ///
     /// Evaluates to ``ASN1Identifier/bitString``.
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .bitString
     }
@@ -50,7 +49,6 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -94,14 +92,12 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     /// - parameters:
     ///     - bytes: The bytes to represent this bitstring
     ///     - paddingBits: The number of bits in the trailing byte that are not actually part of this bitstring.
-    @inlinable
     public init(bytes: ArraySlice<UInt8>, paddingBits: Int = 0) {
         self.bytes = bytes
         self.paddingBits = paddingBits
         try! self._validate()
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             bytes.append(UInt8(truncatingIfNeeded: self.paddingBits))
@@ -109,7 +105,6 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
         }
     }
 
-    @inlinable
     internal func _validate() throws {
         guard let finalByte = self.bytes.last else {
             if self.paddingBits != 0 {
@@ -139,7 +134,6 @@ extension ASN1BitString: Hashable {}
 extension ASN1BitString: Sendable {}
 
 extension ASN1BitString {
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Boolean.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Boolean.swift
@@ -13,12 +13,10 @@
 //===----------------------------------------------------------------------===//
 
 extension Bool: DERImplicitlyTaggable, BERImplicitlyTaggable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .boolean
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -41,7 +39,6 @@ extension Bool: DERImplicitlyTaggable, BERImplicitlyTaggable {
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -61,7 +58,6 @@ extension Bool: DERImplicitlyTaggable, BERImplicitlyTaggable {
         }
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             if self {

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Identifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Identifier.swift
@@ -15,12 +15,11 @@
 /// An ``ASN1Identifier`` is a representation of the abstract notion of an ASN.1 identifier.
 public struct ASN1Identifier {
     /// The base tag.
-    public var tagNumber: UInt
+    public private(set) var tagNumber: UInt
 
     /// The class of the tag.
-    public var tagClass: TagClass
+    public private(set) var tagClass: TagClass
 
-    @inlinable
     var _shortForm: UInt8? {
         // An ASN.1 identifier can be encoded in short form iff the tag number is strictly
         // less than 0x1f.
@@ -38,7 +37,6 @@ public struct ASN1Identifier {
         case contextSpecific
         case `private`
 
-        @inlinable
         init(topByteInWireFormat topByte: UInt8) {
             switch topByte >> 6 {
             case 0x00:
@@ -54,7 +52,6 @@ public struct ASN1Identifier {
             }
         }
 
-        @inlinable
         var _topByteFlags: UInt8 {
             switch self {
             case .universal:
@@ -69,7 +66,6 @@ public struct ASN1Identifier {
         }
     }
 
-    @inlinable
     init(shortIdentifier: UInt8) {
         precondition(shortIdentifier & 0x1F != 0x1F)
         self.tagClass = TagClass(topByteInWireFormat: shortIdentifier)
@@ -81,7 +77,6 @@ public struct ASN1Identifier {
     /// - parameters:
     ///     - number: The tag number.
     ///     - tagClass: The class of the ASN.1 tag.
-    @inlinable
     public init(tagWithNumber number: UInt, tagClass: TagClass) {
         self.tagNumber = number
         self.tagClass = tagClass
@@ -161,14 +156,12 @@ extension ASN1Identifier: Hashable {}
 extension ASN1Identifier: Sendable {}
 
 extension ASN1Identifier: CustomStringConvertible {
-    @inlinable
     public var description: String {
         return "ASN1Identifier(tagNumber: \(self.tagNumber), tagClass: \(self.tagClass))"
     }
 }
 
 extension Array where Element == UInt8 {
-    @inlinable
     mutating func writeIdentifier(_ identifier: ASN1Identifier, constructed: Bool) {
         if var shortForm = identifier._shortForm {
             if constructed {

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
@@ -41,12 +41,10 @@ public protocol ASN1IntegerRepresentable: DERImplicitlyTaggable, BERImplicitlyTa
 }
 
 extension ASN1IntegerRepresentable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .integer
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -86,7 +84,6 @@ extension ASN1IntegerRepresentable {
         self = try Self(derIntegerBytes: dataBytes)
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -114,7 +111,6 @@ extension ASN1IntegerRepresentable {
         self = try Self(berIntegerBytes: dataBytes)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             self.withBigEndianIntegerBytes { integerBytes in
@@ -139,7 +135,6 @@ extension ASN1IntegerRepresentable {
 
 // MARK: - Auto-conformance for FixedWidthInteger with fixed width magnitude.
 extension ASN1IntegerRepresentable where Self: FixedWidthInteger {
-    @inlinable
     public init(derIntegerBytes bytes: ArraySlice<UInt8>) throws {
         // Defer to the FixedWidthInteger constructor.
         // There's a wrinkle here: if this is a signed integer, and the top bit of the data bytes was set,
@@ -154,12 +149,10 @@ extension ASN1IntegerRepresentable where Self: FixedWidthInteger {
         }
     }
 
-    @inlinable
     public init(berIntegerBytes bytes: ArraySlice<UInt8>) throws {
         self = try .init(derIntegerBytes: bytes)
     }
 
-    @inlinable
     public func withBigEndianIntegerBytes<ReturnType>(
         _ body: (IntegerBytesCollection<Self>) throws -> ReturnType
     ) rethrows -> ReturnType {
@@ -169,10 +162,9 @@ extension ASN1IntegerRepresentable where Self: FixedWidthInteger {
 
 /// A big-endian `Collection` of bytes representing a fixed width integer.
 public struct IntegerBytesCollection<Integer: FixedWidthInteger> {
-    @usableFromInline var integer: Integer
+    let integer: Integer
 
     /// Construct an ``IntegerBytesCollection`` representing the bytes of this integer.
-    @inlinable
     public init(_ integer: Integer) {
         self.integer = integer
     }
@@ -184,37 +176,30 @@ extension IntegerBytesCollection: Sendable where Integer: Sendable {}
 
 extension IntegerBytesCollection: RandomAccessCollection {
     public struct Index {
-        @usableFromInline
-        var _byteNumber: Int
+        let _byteNumber: Int
 
-        @inlinable
         init(byteNumber: Int) {
             self._byteNumber = byteNumber
         }
 
-        @inlinable
         var _shift: Integer {
             // As byte number 0 is the end index, the byte number is one byte too large for the shift.
             return Integer((self._byteNumber - 1) * 8)
         }
     }
 
-    @inlinable
     public var startIndex: Index {
         return Index(byteNumber: Int(self.integer.neededBytes))
     }
 
-    @inlinable
     public var endIndex: Index {
         return Index(byteNumber: 0)
     }
 
-    @inlinable
     public var count: Int {
         return Int(self.integer.neededBytes)
     }
 
-    @inlinable
     public subscript(index: Index) -> UInt8 {
         // We perform the bitwise operations in magnitude space.
         let shifted = Integer.Magnitude(truncatingIfNeeded: self.integer) >> index._shift
@@ -229,34 +214,28 @@ extension IntegerBytesCollection.Index: Sendable {}
 
 extension IntegerBytesCollection.Index: Comparable {
     // Comparable here is backwards to the original ordering.
-    @inlinable
     public static func < (lhs: Self, rhs: Self) -> Bool {
         return lhs._byteNumber > rhs._byteNumber
     }
 
-    @inlinable
     public static func > (lhs: Self, rhs: Self) -> Bool {
         return lhs._byteNumber < rhs._byteNumber
     }
 
-    @inlinable
     public static func <= (lhs: Self, rhs: Self) -> Bool {
         return lhs._byteNumber >= rhs._byteNumber
     }
 
-    @inlinable
     public static func >= (lhs: Self, rhs: Self) -> Bool {
         return lhs._byteNumber <= rhs._byteNumber
     }
 }
 
 extension IntegerBytesCollection.Index: Strideable {
-    @inlinable
     public func advanced(by n: Int) -> IntegerBytesCollection<Integer>.Index {
         return IntegerBytesCollection.Index(byteNumber: self._byteNumber - n)
     }
 
-    @inlinable
     public func distance(to other: IntegerBytesCollection<Integer>.Index) -> Int {
         // Remember that early indices have high byte numbers and later indices have low ones.
         return self._byteNumber - other._byteNumber
@@ -284,7 +263,6 @@ extension Int: ASN1IntegerRepresentable {}
 extension UInt: ASN1IntegerRepresentable {}
 
 extension RandomAccessCollection where Element == UInt8 {
-    @inlinable
     func _trimLeadingExcessBytes() -> SubSequence {
         var slice = self[...]
         guard let first = slice.first else {
@@ -332,7 +310,6 @@ extension RandomAccessCollection where Element == UInt8 {
 }
 
 extension UInt8 {
-    @inlinable
     var _topBitSet: Bool {
         return (self & 0x80) != 0
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
@@ -14,16 +14,13 @@
 
 /// An ASN1 NULL represents nothing.
 public struct ASN1Null: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .null
     }
 
     /// Construct a new ASN.1 null.
-    @inlinable
     public init() {}
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier, case .primitive(let content) = node.content else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -34,12 +31,10 @@ public struct ASN1Null: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, 
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try .init(derEncoded: node, withIdentifier: identifier)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) {
         coder.appendPrimitiveNode(identifier: identifier, { _ in })
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1OctetString.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1OctetString.swift
@@ -15,7 +15,6 @@
 /// An OCTET STRING is a representation of a string of octets.
 public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
 
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .octetString
     }
@@ -23,7 +22,6 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     /// The octets that make up this OCTET STRING.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -36,7 +34,6 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
         self.bytes = content
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -87,12 +84,10 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     ///
     /// - parameters:
     ///     - contentBytes: The bytes that make up this OCTET STRING.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             bytes.append(contentsOf: self.bytes)
@@ -105,7 +100,6 @@ extension ASN1OctetString: Hashable {}
 extension ASN1OctetString: Sendable {}
 
 extension ASN1OctetString {
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Strings.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Strings.swift
@@ -16,48 +16,40 @@
 public struct ASN1UTF8String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .utf8String
     }
 
     /// The raw bytes that make up this string.
-    public var bytes: ArraySlice<UInt8>
+    public let bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a UTF8STRING from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
 
     /// Construct a UTF8STRING from a String.
-    @inlinable
     public init(_ string: String) {
         self.bytes = ArraySlice(string.utf8)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
@@ -69,7 +61,6 @@ public struct ASN1UTF8String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hash
 public struct ASN1TeletexString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .teletexString
     }
@@ -77,34 +68,28 @@ public struct ASN1TeletexString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
     /// The raw bytes that make up this string.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a TeletexString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
@@ -120,7 +105,6 @@ public struct ASN1TeletexString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
 public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .printableString
     }
@@ -132,7 +116,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -140,7 +123,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -149,7 +131,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
     }
 
     /// Construct a PrintableString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) throws {
         self.bytes = contentBytes
         guard Self._isValid(self.bytes) else {
@@ -157,14 +138,12 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
         precondition(Self._isValid(self.bytes))
     }
 
     /// Construct a PrintableString from a String.
-    @inlinable
     public init(_ string: String) throws {
         self.bytes = ArraySlice(string.utf8)
 
@@ -173,18 +152,15 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
 
-    @inlinable
     static func _isValid(_ bytes: ArraySlice<UInt8>) -> Bool {
         bytes.allSatisfy {
             switch $0 {
@@ -211,42 +187,35 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
 public struct ASN1UniversalString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .universalString
     }
 
     /// The raw bytes that make up this string.
-    public var bytes: ArraySlice<UInt8>
+    public let bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a UniversalString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
@@ -258,42 +227,35 @@ public struct ASN1UniversalString: DERImplicitlyTaggable, BERImplicitlyTaggable,
 public struct ASN1BMPString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .bmpString
     }
 
     /// The raw bytes that make up this string.
-    public var bytes: ArraySlice<UInt8>
+    public let bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a BMPString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
@@ -309,7 +271,6 @@ public struct ASN1BMPString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
 public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable,
     ExpressibleByStringLiteral
 {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .ia5String
     }
@@ -321,7 +282,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -329,7 +289,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -338,7 +297,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
     }
 
     /// Construct an IA5String from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) throws {
         self.bytes = contentBytes
         guard Self._isValid(self.bytes) else {
@@ -346,14 +304,12 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
         precondition(Self._isValid(self.bytes))
     }
 
     /// Construct an IA5String from a String.
-    @inlinable
     public init(_ string: String) throws {
         self.bytes = ArraySlice(string.utf8)
 
@@ -362,18 +318,15 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         let octet = ASN1OctetString(contentBytes: self.bytes)
         try octet.serialize(into: &coder, withIdentifier: identifier)
     }
 
-    @inlinable
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         return try self.bytes.withUnsafeBytes(body)
     }
 
-    @inlinable
     static func _isValid(_ bytes: ArraySlice<UInt8>) -> Bool {
         // Valid IA5Strings are ASCII characters.
         bytes.allSatisfy { $0 < 128 }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ArraySliceBigint.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ArraySliceBigint.swift
@@ -27,22 +27,18 @@ extension ArraySlice: BERImplicitlyTaggable where Element == UInt8 {}
 
 extension ArraySlice: ASN1IntegerRepresentable where Element == UInt8 {
     // We only use unsigned "bigint"s
-    @inlinable
     public static var isSigned: Bool {
         return false
     }
 
-    @inlinable
     public init(derIntegerBytes: ArraySlice<UInt8>) throws {
         self = derIntegerBytes
     }
 
-    @inlinable
     public init(berIntegerBytes: ArraySlice<UInt8>) throws {
         self = berIntegerBytes
     }
 
-    @inlinable
     public func withBigEndianIntegerBytes<ReturnType>(
         _ body: (ArraySlice<UInt8>) throws -> ReturnType
     ) rethrows -> ReturnType {

--- a/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
@@ -20,13 +20,11 @@
 ///
 /// In BER format, seconds may be omitted, and timezone offsets can be present.
 public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .generalizedTime
     }
 
     /// The numerical year.
-    @inlinable
     public var year: Int {
         get {
             return self._year
@@ -38,7 +36,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The numerical month.
-    @inlinable
     public var month: Int {
         get {
             return self._month
@@ -50,7 +47,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The numerical day.
-    @inlinable
     public var day: Int {
         get {
             return self._day
@@ -62,7 +58,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The numerical hours.
-    @inlinable
     public var hours: Int {
         get {
             return self._hours
@@ -74,7 +69,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The numerical minutes.
-    @inlinable
     public var minutes: Int {
         get {
             return self._minutes
@@ -86,7 +80,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The numerical seconds.
-    @inlinable
     public var seconds: Int {
         get {
             return self._seconds
@@ -98,7 +91,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     }
 
     /// The fractional seconds.
-    @inlinable
     public var fractionalSeconds: Double {
         get {
             return self._fractionalSeconds
@@ -114,7 +106,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
 
     /// The ArraySlice of bytes from which the fractional seconds will be computed. (Preserved due to a possible overflow
     /// when computing a Double from this ArraySlice.)
-    @inlinable
     public var rawFractionalSeconds: ArraySlice<UInt8> {
         get {
             return self._rawFractionalSeconds
@@ -127,16 +118,16 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
         }
     }
 
-    @usableFromInline var _year: Int
-    @usableFromInline var _month: Int
-    @usableFromInline var _day: Int
-    @usableFromInline var _hours: Int
-    @usableFromInline var _minutes: Int
-    @usableFromInline var _seconds: Int
+    private(set) var _year: Int
+    private(set) var _month: Int
+    private(set) var _day: Int
+    private(set) var _hours: Int
+    private(set) var _minutes: Int
+    private(set) var _seconds: Int
     /// `_fractionalSeconds` is a cached value and `_rawFractionalSeconds` is the source of truth for the numerical
     /// fractonal seconds. (No information is lost in the conversion from `_fractionalSeconds` to `_rawFractionalSeconds`.)
-    @usableFromInline var _fractionalSeconds: Double
-    @usableFromInline var _rawFractionalSeconds: ArraySlice<UInt8>
+    private(set) var _fractionalSeconds: Double
+    private(set) var _rawFractionalSeconds: ArraySlice<UInt8>
 
     /// Construct a new ``GeneralizedTime`` from individual components.
     ///
@@ -148,7 +139,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     ///     - minutes: The numerical minutes
     ///     - seconds: The numerical seconds
     ///     - fractionalSeconds: The numerical fractional seconds.
-    @inlinable
     public init(
         year: Int,
         month: Int,
@@ -182,7 +172,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     ///     - seconds: The numerical seconds
     ///     - rawFractionalSeconds: The ArraySlice of bytes from which the fractional seconds will be computed.
     ///     (Preserved due to a possible overflow when computing a Double from this ArraySlice.)
-    @inlinable
     public init(
         year: Int,
         month: Int,
@@ -204,27 +193,23 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
         try self._validate()
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         let content = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         self = try TimeUtilities.generalizedTimeFromBytes(content)
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         // TODO: BER supports relaxed timestamp parsing, which is not yet supported
         let content = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         self = try TimeUtilities.generalizedTimeFromBytes(content)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             bytes.append(self)
         }
     }
 
-    @inlinable
     func _validate() throws {
         // Validate that the structure is well-formed.
         guard self._year >= 0 && self._year <= 9999 else {
@@ -275,7 +260,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
 }
 
 extension GeneralizedTime: Comparable {
-    @inlinable
     public static func < (lhs: GeneralizedTime, rhs: GeneralizedTime) -> Bool {
         if lhs.year < rhs.year { return true } else if lhs.year > rhs.year { return false }
         if lhs.month < rhs.month { return true } else if lhs.month > rhs.month { return false }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -27,15 +27,12 @@
 /// This object also has a number of pre-existing values defined in namespaces. Users are encouraged to create their own namespaces to
 /// make it easier to use OIDs in their own serialization code.
 public struct ASN1ObjectIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .objectIdentifier
     }
 
-    @usableFromInline
-    var bytes: ArraySlice<UInt8>
+    let bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -50,7 +47,6 @@ public struct ASN1ObjectIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable
         self.bytes = content
     }
 
-    @inlinable
     static func validateObjectIdentifierInEncodedForm(_ content: ArraySlice<UInt8>) throws {
         var content = content
 
@@ -64,7 +60,6 @@ public struct ASN1ObjectIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable
     }
 
     /// An array representing the OID components
-    @inlinable
     public var oidComponents: [UInt] {
         var content = bytes
         // We have to parse the content. From the spec:
@@ -122,19 +117,16 @@ public struct ASN1ObjectIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable
         return oidComponents
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             bytes.append(contentsOf: self.bytes)
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identiifer: ASN1Identifier) throws {
         self = try .init(derEncoded: node, withIdentifier: identiifer)
     }
 
-    @inlinable
     static func _writeOIDSubidentifier(_ identifier: UInt, into array: inout [UInt8]) {
         array.writeUsing7BitBytesASN1Discipline(unsignedInteger: identifier)
     }
@@ -147,7 +139,6 @@ extension ASN1ObjectIdentifier: Sendable {}
 extension ASN1ObjectIdentifier {
     /// Initializes ``ASN1ObjectIdentifier`` from its OID components
     /// - Parameter elements: The OID components
-    @inlinable
     public init(elements: some Collection<UInt>) throws {
         var bytes = [UInt8]()
         var iterator = elements.makeIterator()
@@ -169,7 +160,6 @@ extension ASN1ObjectIdentifier {
 }
 
 extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
-    @inlinable
     public init(stringLiteral dotRepresentation: String) {
         // To allow for invalid strings to be tested, parsing is performed in a separate initializer that  `throws`
         // (this initializer conforms to ExpressibleByStringLiteral so cannot throw)
@@ -178,7 +168,6 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
 
     /// Initializes an instance from a `Substring` containing the dot represented OID
     /// - Parameter dotRepresentation: The dot represented OID
-    @inlinable
     public init(dotRepresentation: Substring) throws {
         let octetArray = dotRepresentation.utf8.split(
             separator: UInt8(ascii: "."),
@@ -197,21 +186,18 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
 
     /// Initializes an instance from a `String` containing the dot represented OID
     /// - Parameter dotRepresentation: The dot represented OID
-    @inlinable
     public init(dotRepresentation: String) throws {
         try self.init(dotRepresentation: Substring(dotRepresentation))
     }
 }
 
 extension ASN1ObjectIdentifier: ExpressibleByArrayLiteral {
-    @inlinable
     public init(arrayLiteral elements: UInt...) {
         try! self.init(elements: elements)
     }
 }
 
 extension ASN1ObjectIdentifier: CustomStringConvertible {
-    @inlinable
     public var description: String {
         self.oidComponents.map { String($0) }.joined(separator: ".")
     }
@@ -371,7 +357,6 @@ extension ASN1ObjectIdentifier {
 }
 
 extension ArraySlice where Element == UInt8 {
-    @inlinable
     mutating func readUIntUsing8BitBytesASN1Discipline() throws -> UInt {
         // In principle OID subidentifiers and long tags can be too large to fit into a UInt. We are choosing to not care about that
         // because for us it shouldn't matter.
@@ -395,7 +380,6 @@ extension ArraySlice where Element == UInt8 {
 }
 
 extension UInt {
-    @inlinable
     init<Bytes: Collection>(sevenBitBigEndianBytes bytes: Bytes) throws where Bytes.Element == UInt8 {
         // We need to know how many bytes we _need_ to store this "int". As a base optimization we refuse to parse
         // anything larger than 9 bytes wide, even though conceptually we could fit a few more bits.
@@ -420,7 +404,6 @@ extension UInt {
 }
 
 extension Array where Element == UInt8 {
-    @inlinable
     mutating func writeUsing7BitBytesASN1Discipline(unsignedInteger identifier: UInt) {
         // An OID subidentifier or long-form tag is written as an integer over 7-bit bytes, where the last byte has the top bit unset.
         // The first thing we need is to know how many bits we need to write

--- a/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/PEMDocument.swift
@@ -76,7 +76,6 @@ extension PEMParseable {
     ///
     /// - Parameters:
     ///   - pemString: The PEM-encoded string representing this object.
-    @inlinable
     public init(pemEncoded pemString: String) throws {
         try self.init(pemDocument: try PEMDocument(pemString: pemString))
     }
@@ -87,7 +86,6 @@ extension PEMParseable {
     ///
     /// - Parameters:
     ///   - pemDocument: DER-encoded PEM document
-    @inlinable
     public init(pemDocument: PEMDocument) throws {
         guard pemDocument.discriminator == Self.defaultPEMDiscriminator else {
             throw ASN1Error.invalidPEMDocument(
@@ -104,7 +102,6 @@ extension PEMSerializable {
     /// Serializes `self` as a PEM document with given `discriminator`.
     /// - Parameter discriminator: PEM discriminator used in for the BEGIN and END encapsulation boundaries.
     /// - Returns: DER encoded PEM document
-    @inlinable
     public func serializeAsPEM(discriminator: String) throws -> PEMDocument {
         var serializer = DER.Serializer()
         try serializer.serialize(self)
@@ -113,7 +110,6 @@ extension PEMSerializable {
     }
 
     /// Serializes `self` as a PEM document with the ``defaultPEMDiscriminator``.
-    @inlinable
     public func serializeAsPEM() throws -> PEMDocument {
         try self.serializeAsPEM(discriminator: Self.defaultPEMDiscriminator)
     }
@@ -129,9 +125,9 @@ public struct PEMDocument: Hashable, Sendable {
     /// <base 64 encoded derBytes>
     /// -----END discriminator-----
     /// ```
-    public var discriminator: String
+    public let discriminator: String
 
-    public var derBytes: [UInt8]
+    public let derBytes: [UInt8]
 
     public init(pemString: String) throws {
         var pemString = pemString.utf8[...]

--- a/Sources/SwiftASN1/Basic ASN1 Types/TimeUtilities.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/TimeUtilities.swift
@@ -15,9 +15,7 @@
 @available(*, unavailable)
 extension TimeUtilities: Sendable {}
 
-@usableFromInline
 enum TimeUtilities {
-    @inlinable
     static func generalizedTimeFromBytes(_ bytes: ArraySlice<UInt8>) throws -> GeneralizedTime {
         var bytes = bytes
 
@@ -68,7 +66,6 @@ enum TimeUtilities {
         )
     }
 
-    @inlinable
     static func utcTimeFromBytes(_ bytes: ArraySlice<UInt8>) throws -> UTCTime {
         var bytes = bytes
 
@@ -112,7 +109,6 @@ enum TimeUtilities {
         )
     }
 
-    @inlinable
     static func daysInMonth(_ month: Int, ofYear year: Int) -> Int? {
         switch month {
         case 1:
@@ -150,7 +146,6 @@ enum TimeUtilities {
 }
 
 extension ArraySlice where Element == UInt8 {
-    @inlinable
     mutating func _readFourDigitDecimalInteger() -> Int? {
         guard let first = self._readTwoDigitDecimalInteger(),
             let second = self._readTwoDigitDecimalInteger()
@@ -163,7 +158,6 @@ extension ArraySlice where Element == UInt8 {
         return (first &* 100) &+ second
     }
 
-    @inlinable
     mutating func _readTwoDigitDecimalInteger() -> Int? {
         guard let firstASCII = self.popFirst(),
             let secondASCII = self.popFirst()
@@ -182,7 +176,6 @@ extension ArraySlice where Element == UInt8 {
         return (first &* 10) &+ (second)
     }
 
-    @inlinable
     mutating func _readRawFractionalSeconds() throws -> ArraySlice<UInt8> {
         guard let nonDecimalASCIIIndex = self.firstIndex(where: { Int(fromDecimalASCII: $0) == nil }) else {
             throw ASN1Error.invalidASN1Object(
@@ -203,7 +196,6 @@ extension ArraySlice where Element == UInt8 {
         return rawFractionalSeconds
     }
 
-    @inlinable
     mutating func append(fractionalSeconds: Double) throws {
         // Fractional seconds may not be negative and may not be 1 or more.
         guard fractionalSeconds >= 0 && fractionalSeconds < 1 else {
@@ -224,7 +216,6 @@ extension ArraySlice where Element == UInt8 {
 }
 
 extension Array where Element == UInt8 {
-    @inlinable
     mutating func append(_ generalizedTime: GeneralizedTime) {
         self._appendFourDigitDecimal(generalizedTime.year)
         self._appendTwoDigitDecimal(generalizedTime.month)
@@ -241,7 +232,6 @@ extension Array where Element == UInt8 {
         self.append(UInt8(ascii: "Z"))
     }
 
-    @inlinable
     mutating func append(_ utcTime: UTCTime) {
         precondition((1950..<2050).contains(utcTime.year))
         if utcTime.year >= 2000 {
@@ -257,7 +247,6 @@ extension Array where Element == UInt8 {
         self.append(UInt8(ascii: "Z"))
     }
 
-    @inlinable
     mutating func _appendFourDigitDecimal(_ number: Int) {
         assert(number >= 0 && number <= 9999)
 
@@ -271,7 +260,6 @@ extension Array where Element == UInt8 {
         self.append(UInt8(truncatingIfNeeded: number % 10) &+ asciiZero)
     }
 
-    @inlinable
     mutating func _appendTwoDigitDecimal(_ number: Int) {
         assert(number >= 0 && number <= 99)
 
@@ -285,7 +273,6 @@ extension Array where Element == UInt8 {
 }
 
 extension Int {
-    @inlinable
     init?(fromDecimalASCII ascii: UInt8) {
         let asciiZero = UInt8(ascii: "0")
         let zeroToNine = 0...9
@@ -302,7 +289,6 @@ extension Int {
 }
 
 extension Double {
-    @inlinable
     init(fromRawFractionalSeconds rawFractionalSeconds: ArraySlice<UInt8>) throws {
         if rawFractionalSeconds.count == 0 {
             self = 0

--- a/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
@@ -21,13 +21,11 @@
 /// means that it can only encode dates between 1950 and 2049. For dates outside that range, prefer
 /// ``GeneralizedTime``.
 public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
-    @inlinable
     public static var defaultIdentifier: ASN1Identifier {
         .utcTime
     }
 
     /// The numerical year.
-    @inlinable
     public var year: Int {
         get {
             return self._year
@@ -39,7 +37,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 
     /// The numerical month.
-    @inlinable
     public var month: Int {
         get {
             return self._month
@@ -51,7 +48,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 
     /// The numerical day.
-    @inlinable
     public var day: Int {
         get {
             return self._day
@@ -63,7 +59,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 
     /// The numerical hours.
-    @inlinable
     public var hours: Int {
         get {
             return self._hours
@@ -75,7 +70,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 
     /// The numerical minutes.
-    @inlinable
     public var minutes: Int {
         get {
             return self._minutes
@@ -87,7 +81,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 
     /// The numerical seconds.
-    @inlinable
     public var seconds: Int {
         get {
             return self._seconds
@@ -98,12 +91,12 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
         }
     }
 
-    @usableFromInline var _year: Int
-    @usableFromInline var _month: Int
-    @usableFromInline var _day: Int
-    @usableFromInline var _hours: Int
-    @usableFromInline var _minutes: Int
-    @usableFromInline var _seconds: Int
+    private var _year: Int
+    private var _month: Int
+    private var _day: Int
+    private var _hours: Int
+    private var _minutes: Int
+    private var _seconds: Int
 
     /// Construct a new ``UTCTime`` from individual components.
     ///
@@ -114,7 +107,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     ///     - hours: The numerical hours
     ///     - minutes: The numerical minutes
     ///     - seconds: The numerical seconds
-    @inlinable
     public init(year: Int, month: Int, day: Int, hours: Int, minutes: Int, seconds: Int) throws {
         self._year = year
         self._month = month
@@ -126,26 +118,22 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
         try self._validate()
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         let content = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         self = try TimeUtilities.utcTimeFromBytes(content)
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         let content = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         self = try TimeUtilities.utcTimeFromBytes(content)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         coder.appendPrimitiveNode(identifier: identifier) { bytes in
             bytes.append(self)
         }
     }
 
-    @inlinable
     func _validate() throws {
         // Validate that the structure is well-formed.
         // UTCTime can only hold years between 1950 and 2049.
@@ -181,7 +169,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
 }
 
 extension UTCTime: Comparable {
-    @inlinable
     public static func < (lhs: UTCTime, rhs: UTCTime) -> Bool {
         if lhs.year < rhs.year { return true } else if lhs.year > rhs.year { return false }
         if lhs.month < rhs.month { return true } else if lhs.month > rhs.month { return false }

--- a/Sources/SwiftASN1/DER.swift
+++ b/Sources/SwiftASN1/DER.swift
@@ -21,7 +21,6 @@ extension DER: Sendable {}
 
 // MARK: - Parser Node
 extension DER {
-    @usableFromInline
     typealias ParserNode = ASN1.ParserNode
 }
 
@@ -35,7 +34,6 @@ extension DER {
     ///     - node: The ``ASN1Node`` to parse
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE is expected to have.
     ///     - builder: A closure that will be called with the collection of nodes within the sequence.
-    @inlinable
     public static func sequence<T>(
         _ node: ASN1Node,
         identifier: ASN1Identifier,
@@ -65,7 +63,6 @@ extension DER {
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func sequence<T: DERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -87,7 +84,6 @@ extension DER {
     ///     - identifier: The ``ASN1Identifier`` that the SEQUENCE OF is expected to have.
     ///     - nodes: An ``ASN1NodeCollection/Iterator`` of nodes to parse.
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func sequence<T: DERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -111,7 +107,6 @@ extension DER {
     ///     - node: The ``ASN1Node`` to parse
     ///     - identifier: The ``ASN1Identifier`` that the SET is expected to have.
     ///     - builder: A closure that will be called with the collection of nodes within the set.
-    @inlinable
     public static func set<T>(
         _ node: ASN1Node,
         identifier: ASN1Identifier,
@@ -130,7 +125,6 @@ extension DER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - nodes: An ``ASN1NodeCollection/Iterator`` of nodes to parse.
     /// - returns: An array of elements representing the elements in the set.
-    @inlinable
     public static func set<T: DERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -155,7 +149,6 @@ extension DER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: An array of elements representing the elements in the sequence.
-    @inlinable
     public static func set<T: DERParseable>(
         of type: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -173,7 +166,6 @@ extension DER {
     ///     - identifier: The ``ASN1Identifier`` that the SET OF is expected to have.
     ///     - rootNode: The ``ASN1Node`` to parse
     /// - returns: A `Sequence` of elements representing the `Result` of parsing the elements in the sequence.
-    @inlinable
     public static func lazySet<T: DERParseable>(
         of: T.Type = T.self,
         identifier: ASN1Identifier,
@@ -208,7 +200,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The result of `builder` if the element was present, or `nil` if it was not.
-    @inlinable
     public static func optionalExplicitlyTagged<T>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -258,7 +249,6 @@ extension DER {
     ///     - tag: The implicit tag. Defaults to the default tag for the element.
     ///
     /// - returns: The parsed element, if it was present, or `nil` if it was not.
-    @inlinable
     public static func optionalImplicitlyTagged<T: DERImplicitlyTaggable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tag: ASN1Identifier = T.defaultIdentifier
@@ -287,7 +277,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The result of `builder` if the element was present, or `nil` if it was not.
-    @inlinable
     public static func optionalImplicitlyTagged<Result>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -327,7 +316,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: DERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         identifier: ASN1Identifier,
@@ -375,7 +363,6 @@ extension DER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: DERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         identifier: ASN1Identifier,
@@ -397,7 +384,6 @@ extension DER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefault<T: DERImplicitlyTaggable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         defaultValue: T
@@ -417,7 +403,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element, if the element is present.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefaultExplicitlyTagged<T: DERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -454,7 +439,6 @@ extension DER {
     ///     - defaultValue: The default value to use if there was no encoded value.
     ///
     /// - returns: The parsed element, if it was present, or the default if it was not.
-    @inlinable
     public static func decodeDefaultExplicitlyTagged<T: DERParseable & Equatable>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -483,7 +467,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element.
     ///
     /// - returns: The result of `builder`.
-    @inlinable
     public static func explicitlyTagged<T>(
         _ nodes: inout ASN1NodeCollection.Iterator,
         tagNumber: UInt,
@@ -510,7 +493,6 @@ extension DER {
     ///     - builder: A closure that will be called with the node for the element.
     ///
     /// - returns: The result of `builder`.
-    @inlinable
     public static func explicitlyTagged<T>(
         _ node: ASN1Node,
         tagNumber: UInt,
@@ -542,7 +524,6 @@ extension DER {
 // MARK: - Parsing
 extension DER {
     /// A parsed representation of ASN.1.
-    @usableFromInline
     typealias ParseResult = ASN1.ParseResult
 }
 
@@ -559,7 +540,6 @@ extension DER {
     /// - parameters:
     ///     - data: The DER-encoded bytes to parse.
     /// - returns: The root node in the ASN.1 tree.
-    @inlinable
     public static func parse(_ data: [UInt8]) throws -> ASN1Node {
         return try parse(data[...])
     }
@@ -576,7 +556,6 @@ extension DER {
     /// - parameters:
     ///     - data: The DER-encoded bytes to parse.
     /// - returns: The root node in the ASN.1 tree.
-    @inlinable
     public static func parse(_ data: ArraySlice<UInt8>) throws -> ASN1Node {
         var result = try ParseResult.parse(data, encoding: .distinguished)
 
@@ -613,18 +592,15 @@ extension DER {
     ///
     /// ``Serializer`` is a copy-on-write value type.
     public struct Serializer: Sendable {
-        @usableFromInline
-        var _serializedBytes: [UInt8]
+            var _serializedBytes: [UInt8]
 
         /// The bytes that have been serialized by this serializer.
-        @inlinable
-        public var serializedBytes: [UInt8] {
+            public var serializedBytes: [UInt8] {
             self._serializedBytes
         }
 
         /// Construct a new serializer.
-        @inlinable
-        public init() {
+            public init() {
             // We allocate a 1kB array because that should cover us most of the time.
             self._serializedBytes = []
             self._serializedBytes.reserveCapacity(1024)
@@ -637,8 +613,7 @@ extension DER {
         /// - parameters:
         ///      - identifier: The tag for this ASN.1 node
         ///      - contentWriter: A callback that will be invoked that allows users to write their bytes into the output stream.
-        @inlinable
-        public mutating func appendPrimitiveNode(
+            public mutating func appendPrimitiveNode(
             identifier: ASN1Identifier,
             _ contentWriter: (inout [UInt8]) throws -> Void
         ) rethrows {
@@ -653,8 +628,7 @@ extension DER {
         /// - parameters:
         ///      - identifier: The tag for this ASN.1 node
         ///      - contentWriter: A callback that will be invoked that allows users to write the objects contained within this constructed node.
-        @inlinable
-        public mutating func appendConstructedNode(
+            public mutating func appendConstructedNode(
             identifier: ASN1Identifier,
             _ contentWriter: (inout Serializer) throws -> Void
         ) rethrows {
@@ -665,8 +639,7 @@ extension DER {
         ///
         /// - parameters:
         ///     node: The node to be serialized.
-        @inlinable
-        public mutating func serialize<T: DERSerializable>(_ node: T) throws {
+            public mutating func serialize<T: DERSerializable>(_ node: T) throws {
             try node.serialize(into: &self)
         }
 
@@ -679,8 +652,7 @@ extension DER {
         ///     node: The node to be serialized.
         ///     tagNumber: The number of the explicit tag.
         ///     tagClass: The number of the explicit tag.
-        @inlinable
-        public mutating func serialize<T: DERSerializable>(
+            public mutating func serialize<T: DERSerializable>(
             _ node: T,
             explicitlyTaggedWithTagNumber tagNumber: UInt,
             tagClass: ASN1Identifier.TagClass
@@ -694,8 +666,7 @@ extension DER {
         /// - parameters:
         ///     node: The node to be serialized.
         ///     identifier: The explicit ASN.1 tag to apply.
-        @inlinable
-        public mutating func serialize<T: DERSerializable>(
+            public mutating func serialize<T: DERSerializable>(
             _ node: T,
             explicitlyTaggedWithIdentifier identifier: ASN1Identifier
         ) throws {
@@ -712,8 +683,7 @@ extension DER {
         ///
         /// - parameters:
         ///     node: The node to be serialized.
-        @inlinable
-        public mutating func serializeOptionalImplicitlyTagged<T: DERSerializable>(_ node: T?) throws {
+            public mutating func serializeOptionalImplicitlyTagged<T: DERSerializable>(_ node: T?) throws {
             if let node = node {
                 try self.serialize(node)
             }
@@ -726,8 +696,7 @@ extension DER {
         /// - parameters:
         ///     node: The node to be serialized.
         ///     identifier: The implicit ASN.1 tag to apply.
-        @inlinable
-        public mutating func serializeOptionalImplicitlyTagged<T: DERImplicitlyTaggable>(
+            public mutating func serializeOptionalImplicitlyTagged<T: DERImplicitlyTaggable>(
             _ node: T?,
             withIdentifier identifier: ASN1Identifier
         ) throws {
@@ -745,8 +714,7 @@ extension DER {
         ///     tagNumber: The number of the explicit tag.
         ///     tagClass: The number of the explicit tag.
         ///     block: The block that will be invoked to encode the contents of the explicit tag.
-        @inlinable
-        public mutating func serialize(
+            public mutating func serialize(
             explicitlyTaggedWithTagNumber tagNumber: UInt,
             tagClass: ASN1Identifier.TagClass,
             _ block: (inout Serializer) throws -> Void
@@ -762,8 +730,7 @@ extension DER {
         /// - parameters:
         ///     - elements: The members of the ASN.1 SEQUENCE OF.
         ///     - identifier: The identifier to use for the SEQUENCE OF node. Defaults to ``ASN1Identifier/sequence``.
-        @inlinable
-        public mutating func serializeSequenceOf<Elements: Sequence>(
+            public mutating func serializeSequenceOf<Elements: Sequence>(
             _ elements: Elements,
             identifier: ASN1Identifier = .sequence
         ) throws where Elements.Element: DERSerializable {
@@ -779,8 +746,7 @@ extension DER {
         /// - parameters:
         ///     - elements: The members of the ASN.1 SET OF.
         ///     - identifier: The identifier to use for the SET OF node. Defaults to ``ASN1Identifier/set``.
-        @inlinable
-        public mutating func serializeSetOf<Elements: Sequence>(
+            public mutating func serializeSetOf<Elements: Sequence>(
             _ elements: Elements,
             identifier: ASN1Identifier = .set
         ) throws where Elements.Element: DERSerializable {
@@ -818,8 +784,7 @@ extension DER {
         ///
         /// - parameters:
         ///     - node: The parsed node to serialize.
-        @inlinable
-        public mutating func serialize(_ node: ASN1Node) {
+            public mutating func serialize(_ node: ASN1Node) {
             let identifier = node.identifier
             let constructed: Bool
 
@@ -853,15 +818,13 @@ extension DER {
         ///
         /// - parameters:
         ///     - bytes: The raw bytes to serialize. These bytes must be well-formed DER.
-        @inlinable
-        public mutating func serializeRawBytes<Bytes: Sequence>(_ bytes: Bytes) where Bytes.Element == UInt8 {
+            public mutating func serializeRawBytes<Bytes: Sequence>(_ bytes: Bytes) where Bytes.Element == UInt8 {
             self._serializedBytes.append(contentsOf: bytes)
         }
 
         // This is the base logical function that all other append methods are built on. This one has most of the logic, and doesn't
         // police what we expect to happen in the content writer.
-        @inlinable
-        mutating func _appendNode(
+            mutating func _appendNode(
             identifier: ASN1Identifier,
             constructed: Bool,
             _ contentWriter: (inout Serializer) throws -> Void
@@ -943,7 +906,6 @@ extension DERParseable {
     /// - parameters:
     ///     - sequenceNodeIterator: The sequence of nodes that make up this object's parent. The first node in this collection
     ///         will be used to construct this object.
-    @inlinable
     public init(derEncoded sequenceNodeIterator: inout ASN1NodeCollection.Iterator) throws {
         guard let node = sequenceNodeIterator.next() else {
             throw ASN1Error.invalidASN1Object(reason: "Unable to decode \(Self.self), no ASN.1 nodes to decode")
@@ -956,7 +918,6 @@ extension DERParseable {
     ///
     /// - parameters:
     ///     - derEncoded: The DER-encoded bytes representing this object.
-    @inlinable
     public init(derEncoded: [UInt8]) throws {
         self = try .init(derEncoded: DER.parse(derEncoded))
     }
@@ -965,7 +926,6 @@ extension DERParseable {
     ///
     /// - parameters:
     ///     - derEncoded: The DER-encoded bytes representing this object.
-    @inlinable
     public init(derEncoded: ArraySlice<UInt8>) throws {
         self = try .init(derEncoded: DER.parse(derEncoded))
     }
@@ -1026,7 +986,6 @@ extension DERImplicitlyTaggable {
     ///     - sequenceNodeIterator: The sequence of nodes that make up this object's parent. The first node in this collection
     ///         will be used to construct this object.
     ///     - identifier: The ASN.1 identifier that `derEncoded` is expected to have.
-    @inlinable
     public init(
         derEncoded sequenceNodeIterator: inout ASN1NodeCollection.Iterator,
         withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier
@@ -1043,7 +1002,6 @@ extension DERImplicitlyTaggable {
     /// - parameters:
     ///     - derEncoded: The DER-encoded bytes representing this object.
     ///     - identifier: The ASN.1 identifier that `derEncoded` is expected to have.
-    @inlinable
     public init(derEncoded: [UInt8], withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier) throws {
         self = try .init(derEncoded: DER.parse(derEncoded), withIdentifier: identifier)
     }
@@ -1053,7 +1011,6 @@ extension DERImplicitlyTaggable {
     /// - parameters:
     ///     - derEncoded: The DER-encoded bytes representing this object.
     ///     - identifier: The ASN.1 identifier that `derEncoded` is expected to have.
-    @inlinable
     public init(
         derEncoded: ArraySlice<UInt8>,
         withIdentifier identifier: ASN1Identifier = Self.defaultIdentifier
@@ -1061,12 +1018,10 @@ extension DERImplicitlyTaggable {
         self = try .init(derEncoded: DER.parse(derEncoded), withIdentifier: identifier)
     }
 
-    @inlinable
     public init(derEncoded: ASN1Node) throws {
         try self.init(derEncoded: derEncoded, withIdentifier: Self.defaultIdentifier)
     }
 
-    @inlinable
     public func serialize(into coder: inout DER.Serializer) throws {
         try self.serialize(into: &coder, withIdentifier: Self.defaultIdentifier)
     }

--- a/Tests/SwiftASN1Tests/Test Helper Types/CMSContentInfo.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/CMSContentInfo.swift
@@ -19,9 +19,9 @@ struct CMSContentInfo: BERImplicitlyTaggable, DERImplicitlyTaggable, Hashable {
         .sequence
     }
 
-    public var contentType: ASN1ObjectIdentifier
+    let contentType: ASN1ObjectIdentifier
 
-    var content: ASN1Any
+    let content: ASN1Any
 
     init(contentType: ASN1ObjectIdentifier, content: ASN1Any) {
         self.contentType = contentType

--- a/Tests/SwiftASN1Tests/Test Helper Types/ECDSASignature.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/ECDSASignature.swift
@@ -24,8 +24,8 @@ struct ECDSASignature<IntegerType: ASN1IntegerRepresentable>: DERImplicitlyTagga
         .sequence
     }
 
-    var r: IntegerType
-    var s: IntegerType
+    let r: IntegerType
+    let s: IntegerType
 
     init(r: IntegerType, s: IntegerType) {
         self.r = r

--- a/Tests/SwiftASN1Tests/Test Helper Types/PKCS8PrivateKey.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/PKCS8PrivateKey.swift
@@ -39,9 +39,9 @@ struct PKCS8PrivateKey: DERImplicitlyTaggable {
         return .sequence
     }
 
-    var algorithm: RFC5480AlgorithmIdentifier
+    let algorithm: RFC5480AlgorithmIdentifier
 
-    var privateKey: SEC1PrivateKey
+    let privateKey: SEC1PrivateKey
 
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in

--- a/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/SEC1PrivateKey.swift
@@ -28,11 +28,11 @@ struct SEC1PrivateKey: DERImplicitlyTaggable, PEMRepresentable {
         return .sequence
     }
 
-    var algorithm: RFC5480AlgorithmIdentifier?
+    let algorithm: RFC5480AlgorithmIdentifier?
 
-    var privateKey: ASN1OctetString
+    let privateKey: ASN1OctetString
 
-    var publicKey: ASN1BitString?
+    let publicKey: ASN1BitString?
 
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in

--- a/Tests/SwiftASN1Tests/Test Helper Types/SubjectPublicKeyInfo.swift
+++ b/Tests/SwiftASN1Tests/Test Helper Types/SubjectPublicKeyInfo.swift
@@ -18,9 +18,9 @@ struct SubjectPublicKeyInfo: DERImplicitlyTaggable, Hashable {
         .sequence
     }
 
-    var algorithmIdentifier: RFC5480AlgorithmIdentifier
+    let algorithmIdentifier: RFC5480AlgorithmIdentifier
 
-    var key: ASN1BitString
+    let key: ASN1BitString
 
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         // The SPKI block looks like this:
@@ -60,9 +60,9 @@ struct RFC5480AlgorithmIdentifier: DERImplicitlyTaggable, Hashable {
         .sequence
     }
 
-    var algorithm: ASN1ObjectIdentifier
+    let algorithm: ASN1ObjectIdentifier
 
-    var parameters: ASN1Any?
+    let parameters: ASN1Any?
 
     init(algorithm: ASN1ObjectIdentifier, parameters: ASN1Any?) {
         self.algorithm = algorithm


### PR DESCRIPTION
When trying to use .swiftinterface (which are generated with xcodebuild BUILD_LIBRARY_FOR_DISTRIBUTION=YES) for occur due to using a big number of @inlinable and @usabelFromInline declarations
