### PR TITLE
Enable macOS CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,5 @@ jobs:
     name: macOS tests
     uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
     with:
+      runner_pool: nightly
       build_scheme: swift-asn1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,3 +52,10 @@ jobs:
             { "name": "SwiftASN1", "type": "source", "exceptions": [] }
           ]
         }
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      runner_pool: general
+      build_scheme: swift-asn1


### PR DESCRIPTION
Motivation:

* Improve test coverage

Modifications:

Enable macOS CI to be run on pull request commits and make the use of the nightly runner pool for main.yml jobs explicit.

Result:

Improved test coverage.
