### PR TITLE
Enable Swift 6.2 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,17 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       windows_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
@@ -55,5 +58,6 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,14 +18,17 @@ jobs:
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
       windows_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
@@ -70,5 +73,6 @@ jobs:
     with:
       windows_6_0_enabled: true
       windows_6_1_enabled: true
+      windows_6_2_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true

--- a/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_PEM_to_PEMDocument.p90.json
@@ -1,0 +1,6 @@
+{
+  "mallocCountTotal" : 565,
+  "memoryLeaked" : 0,
+  "readSyscalls" : 0,
+  "writeSyscalls" : 0
+}

--- a/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument.p90.json
@@ -1,0 +1,6 @@
+{
+  "mallocCountTotal" : 572,
+  "memoryLeaked" : 0,
+  "readSyscalls" : 0,
+  "writeSyscalls" : 0
+}

--- a/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftASN1Benchmark.Parse_WebPKI_Roots_from_multi_PEM_to_PEMDocument_.p90.json
@@ -1,0 +1,6 @@
+{
+  "mallocCountTotal" : 967,
+  "memoryLeaked" : 0,
+  "readSyscalls" : 0,
+  "writeSyscalls" : 0
+}


### PR DESCRIPTION
Motivation:

Swift 6.2 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.2 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
