### PR TITLE
Add a failable initializer for parsing untrusted OID strings

### DIFF
--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -201,6 +201,58 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
     public init(dotRepresentation: String) throws {
         try self.init(dotRepresentation: Substring(dotRepresentation))
     }
+
+    /// Initializes an instance from a `String` containing the dot represented OID,
+    /// returning `nil` if the string is not a well-formed OID.
+    ///
+    /// This initializer is suitable for parsing OID strings that come from
+    /// untrusted sources. In addition to the syntactic checks performed by the
+    /// throwing variants, it also validates the first two arcs against the
+    /// ASN.1 OID rules from ITU-T X.690 §8.19.4 (first arc in `0...2`; second
+    /// arc less than `40` when the first arc is `0` or `1`) and uses
+    /// overflow-reporting arithmetic when computing the encoded first
+    /// subidentifier. Inputs that violate these rules, or that would cause
+    /// `(firstComponent * 40) + secondComponent` to overflow `UInt`, return
+    /// `nil` rather than terminating the process.
+    ///
+    /// - Parameter dotRepresentation: The dot represented OID.
+    @inlinable
+    public init?(validating dotRepresentation: String) {
+        let octets = dotRepresentation.utf8.split(
+            separator: UInt8(ascii: "."),
+            omittingEmptySubsequences: false
+        )
+
+        var iterator = octets.makeIterator()
+        guard let firstOctet = iterator.next(), let secondOctet = iterator.next() else {
+            return nil
+        }
+        guard let firstComponent = UInt(Substring(firstOctet)),
+            let secondComponent = UInt(Substring(secondOctet))
+        else {
+            return nil
+        }
+
+        // X.690 §8.19.4: first arc must be 0, 1, or 2; when the first arc is
+        // 0 or 1 the second arc must be less than 40.
+        guard firstComponent <= 2 else { return nil }
+        if firstComponent < 2, secondComponent >= 40 { return nil }
+
+        // The validation above bounds `firstComponent * 40` to at most 80, so
+        // the multiplication cannot overflow. The addition can still overflow
+        // when `firstComponent == 2` and `secondComponent` is close to
+        // `UInt.max`, which we surface as `nil` rather than a runtime trap.
+        let (firstSubidentifier, overflow) = (firstComponent * 40).addingReportingOverflow(secondComponent)
+        guard !overflow else { return nil }
+
+        var bytes = [UInt8]()
+        ASN1ObjectIdentifier._writeOIDSubidentifier(firstSubidentifier, into: &bytes)
+        while let octet = iterator.next() {
+            guard let component = UInt(Substring(octet)) else { return nil }
+            ASN1ObjectIdentifier._writeOIDSubidentifier(component, into: &bytes)
+        }
+        self.bytes = bytes[...]
+    }
 }
 
 extension ASN1ObjectIdentifier: ExpressibleByArrayLiteral {

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -197,11 +197,10 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
     /// returning `nil` if the string is not a well-formed OID.
     ///
     /// This initializer is suitable for parsing OID strings that come from
-    /// untrusted sources. In addition to the syntactic checks performed by the
-    /// throwing variants, it also validates the first two arcs against the
-    /// ASN.1 OID rules from ITU-T X.690 §8.19.4 (first arc in `0...2`; second
-    /// arc less than `40` when the first arc is `0` or `1`) and uses
-    /// overflow-reporting arithmetic when computing the encoded first
+    /// untrusted sources. It validates the string syntax and the first two arcs
+    /// against the ASN.1 OID rules from ITU-T X.690 §8.19.4 (first arc in
+    /// `0...2`; second arc less than `40` when the first arc is `0` or `1`)
+    /// and uses overflow-reporting arithmetic when computing the encoded first
     /// subidentifier. Inputs that violate these rules, or that would cause
     /// `(firstComponent * 40) + secondComponent` to overflow `UInt`, return
     /// `nil` rather than terminating the process.

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -242,16 +242,16 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
         // the multiplication cannot overflow. The addition can still overflow
         // when `firstComponent == 2` and `secondComponent` is close to
         // `UInt.max`, which we surface as `nil` rather than a runtime trap.
-        let (firstSubidentifier, overflow) = (firstComponent * 40).addingReportingOverflow(secondComponent)
+        let (_, overflow) = (firstComponent * 40).addingReportingOverflow(secondComponent)
         guard !overflow else { return nil }
 
-        var bytes = [UInt8]()
-        ASN1ObjectIdentifier._writeOIDSubidentifier(firstSubidentifier, into: &bytes)
+        var components = [firstComponent, secondComponent]
         while let octet = iterator.next() {
             guard let component = UInt(Substring(octet)) else { return nil }
-            ASN1ObjectIdentifier._writeOIDSubidentifier(component, into: &bytes)
+            components.append(component)
         }
-        self.bytes = bytes[...]
+
+        try! self.init(elements: components)
     }
 }
 

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -180,26 +180,17 @@ extension ASN1ObjectIdentifier: ExpressibleByStringLiteral {
     /// - Parameter dotRepresentation: The dot represented OID
     @inlinable
     public init(dotRepresentation: Substring) throws {
-        let octetArray = dotRepresentation.utf8.split(
-            separator: UInt8(ascii: "."),
-            omittingEmptySubsequences: false
-        )
-
-        try self.init(
-            elements: octetArray.lazy.map { octet in
-                guard let uintOctet = UInt(Substring(octet)) else {
-                    throw ASN1Error.invalidStringRepresentation(reason: "Invalid octet in OID")
-                }
-                return uintOctet
-            }
-        )
+        try self.init(dotRepresentation: String(dotRepresentation))
     }
 
     /// Initializes an instance from a `String` containing the dot represented OID
     /// - Parameter dotRepresentation: The dot represented OID
     @inlinable
     public init(dotRepresentation: String) throws {
-        try self.init(dotRepresentation: Substring(dotRepresentation))
+        guard let oid = Self(validating: dotRepresentation) else {
+            throw ASN1Error.invalidStringRepresentation(reason: "Invalid OID string")
+        }
+        self = oid
     }
 
     /// Initializes an instance from a `String` containing the dot represented OID,

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -1287,8 +1287,7 @@ class ASN1Tests: XCTestCase {
         XCTAssertNil(ASN1ObjectIdentifier(validating: "1.40"))
 
         // Component values that would overflow the encoded first subidentifier.
-        // The throwing variant terminates the process on these inputs; the
-        // failable variant must surface them as `nil`.
+        // The failable variant must surface them as `nil`.
         XCTAssertNil(ASN1ObjectIdentifier(validating: "461168601842738791.0"))
         XCTAssertNil(ASN1ObjectIdentifier(validating: "2.18446744073709551615"))
     }

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -1220,6 +1220,35 @@ class ASN1Tests: XCTestCase {
         }
     }
 
+    func testOIDFailableStringInitializer() {
+        // Happy paths return a non-nil value equal to the array-literal form.
+        XCTAssertEqual(
+            ASN1ObjectIdentifier(validating: "1.2.865.11241.3"),
+            [1, 2, 865, 11241, 3] as ASN1ObjectIdentifier
+        )
+        XCTAssertEqual(
+            ASN1ObjectIdentifier(validating: "2.5.4.41"),
+            [2, 5, 4, 41] as ASN1ObjectIdentifier
+        )
+
+        // Malformed strings.
+        XCTAssertNil(ASN1ObjectIdentifier(validating: ""))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "25"))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "1..2.3"))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "1.2.<bogus>"))
+
+        // Out-of-range arcs per X.690 §8.19.4.
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "3.0"))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "0.40"))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "1.40"))
+
+        // Component values that would overflow the encoded first subidentifier.
+        // The throwing variant terminates the process on these inputs; the
+        // failable variant must surface them as `nil`.
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "461168601842738791.0"))
+        XCTAssertNil(ASN1ObjectIdentifier(validating: "2.18446744073709551615"))
+    }
+
     func testSetOfSingleElement() throws {
         var serializer = DER.Serializer()
         try serializer.serializeSetOf([

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -1260,7 +1260,7 @@ class ASN1Tests: XCTestCase {
         }
 
         XCTAssertThrowsError(try ASN1ObjectIdentifier(dotRepresentation: "25")) { error in
-            XCTAssertEqual((error as? ASN1Error)?.code, .tooFewOIDComponents)
+            XCTAssertEqual((error as? ASN1Error)?.code, .invalidStringRepresentation)
         }
     }
 


### PR DESCRIPTION
Motivation:

`ASN1ObjectIdentifier.init(dotRepresentation:)` is documented as a parser for already-validated input and used to terminate the process when the components did not satisfy the ASN.1 OID rules from ITU-T X.690 8.19.4 or when the encoding step
`(firstComponent * 40) + secondComponent` overflowed `UInt`. Callers that need to accept OID strings from untrusted sources currently have no built-in way to reject malformed input without risking a process abort.

Modifications:

* Add `ASN1ObjectIdentifier.init?(validating: String)` alongside the existing throwing variant. The new initializer validates the string syntax, validates the first arc (must be 0, 1, or 2) and the second arc (must be less than 40 when the first is 0 or 1), and uses `addingReportingOverflow` for the residual case where the first arc is 2 and the second arc is close to `UInt.max`. Any failure returns `nil`.
* Rewrite the existing throwing dot-representation initializers to delegate through the validating initializer, keeping the parsing and encoding logic shared.
* Add a new test, `testOIDFailableStringInitializer`, covering the happy path and every rejection case (malformed input, out-of-range first/second arcs, both overflow paths).

Result:

Callers can now parse OID strings from untrusted sources by writing `ASN1ObjectIdentifier(validating: input)` and treating a `nil` result as a parse failure, with no risk of terminating the process.
