### PR TITLE
 Fix Swift 6.2 library evolution build failures caused by @inlinable initializer restrictions

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -84,7 +84,7 @@ extension ASN1 {
         @usableFromInline
         var dataBytes: ArraySlice<UInt8>?
 
-        @inlinable
+        @usableFromInline
         init(
             identifier: ASN1Identifier,
             depth: Int,
@@ -134,7 +134,7 @@ extension ASN1 {
         @usableFromInline
         var nodes: ArraySlice<ParserNode>
 
-        @inlinable
+        @usableFromInline
         init(_ nodes: ArraySlice<ParserNode>) {
             self.nodes = nodes
         }
@@ -285,7 +285,7 @@ extension ASN1 {
                 wrapped.next()
             }
 
-            @inlinable
+            @usableFromInline
             init(_ wrapped: WrappedSequence.Iterator) {
                 self.wrapped = wrapped
             }
@@ -294,7 +294,6 @@ extension ASN1 {
         @usableFromInline
         var wrapped: WrappedSequence
 
-        @inlinable
         init(_ wrapped: WrappedSequence) {
             self.wrapped = wrapped
         }
@@ -324,7 +323,7 @@ public struct ASN1NodeCollection {
 
     @usableFromInline var _depth: Int
 
-    @inlinable
+    @usableFromInline
     init(nodes: ArraySlice<ASN1.ParserNode>, depth: Int) {
         self._nodes = nodes
         self._depth = depth
@@ -349,7 +348,7 @@ extension ASN1NodeCollection: Sequence {
         @usableFromInline
         var _depth: Int
 
-        @inlinable
+        @usableFromInline
         init(nodes: ArraySlice<ASN1.ParserNode>, depth: Int) {
             self._nodes = nodes
             self._depth = depth
@@ -408,8 +407,8 @@ public struct ASN1Node: Hashable, Sendable {
     /// This is principally intended for diagnostic purposes.
     public var encodedBytes: ArraySlice<UInt8>
 
-    @inlinable
-    internal init(
+    @usableFromInline
+    init(
         identifier: ASN1Identifier,
         content: ASN1Node.Content,
         encodedBytes: ArraySlice<UInt8>

--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -294,6 +294,7 @@ extension ASN1 {
         @usableFromInline
         var wrapped: WrappedSequence
 
+        @usableFromInline
         init(_ wrapped: WrappedSequence) {
             self.wrapped = wrapped
         }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
@@ -23,6 +23,11 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
     @usableFromInline
     var _serializedBytes: ArraySlice<UInt8>
 
+    @usableFromInline
+    init(_serializedBytes: ArraySlice<UInt8>) {
+        self._serializedBytes = _serializedBytes
+    }
+
     /// Create an ``ASN1Any`` from a serializable ASN1 type.
     ///
     /// - parameters:
@@ -31,7 +36,7 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
     public init<ASN1Type: DERSerializable>(erasing: ASN1Type) throws {
         var serializer = DER.Serializer()
         try erasing.serialize(into: &serializer)
-        self._serializedBytes = ArraySlice(serializer._serializedBytes)
+        self.init(_serializedBytes: ArraySlice(serializer._serializedBytes))
     }
 
     /// Create an ``ASN1Any`` from a serializable implicitly taggable ASN1 type.
@@ -43,7 +48,7 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
     public init<ASN1Type: DERImplicitlyTaggable>(erasing: ASN1Type, withIdentifier identifier: ASN1Identifier) throws {
         var serializer = DER.Serializer()
         try erasing.serialize(into: &serializer, withIdentifier: identifier)
-        self._serializedBytes = ArraySlice(serializer._serializedBytes)
+        self.init(_serializedBytes: ArraySlice(serializer._serializedBytes))
     }
 
     public init(derEncoded rootNode: ASN1Node) {

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Any.swift
@@ -46,7 +46,6 @@ public struct ASN1Any: DERParseable, BERParseable, DERSerializable, BERSerializa
         self._serializedBytes = ArraySlice(serializer._serializedBytes)
     }
 
-    @inlinable
     public init(derEncoded rootNode: ASN1Node) {
         // This is a bit sad: we just re-serialize this data. In an ideal world
         // we'd update the parse representation so that all nodes can point at their

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1BitString.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1BitString.swift
@@ -50,7 +50,6 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -94,7 +93,6 @@ public struct ASN1BitString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     /// - parameters:
     ///     - bytes: The bytes to represent this bitstring
     ///     - paddingBits: The number of bits in the trailing byte that are not actually part of this bitstring.
-    @inlinable
     public init(bytes: ArraySlice<UInt8>, paddingBits: Int = 0) {
         self.bytes = bytes
         self.paddingBits = paddingBits

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Identifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Identifier.swift
@@ -69,7 +69,7 @@ public struct ASN1Identifier {
         }
     }
 
-    @inlinable
+    @usableFromInline
     init(shortIdentifier: UInt8) {
         precondition(shortIdentifier & 0x1F != 0x1F)
         self.tagClass = TagClass(topByteInWireFormat: shortIdentifier)
@@ -81,7 +81,6 @@ public struct ASN1Identifier {
     /// - parameters:
     ///     - number: The tag number.
     ///     - tagClass: The class of the ASN.1 tag.
-    @inlinable
     public init(tagWithNumber number: UInt, tagClass: TagClass) {
         self.tagNumber = number
         self.tagClass = tagClass

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Integer.swift
@@ -172,7 +172,6 @@ public struct IntegerBytesCollection<Integer: FixedWidthInteger> {
     @usableFromInline var integer: Integer
 
     /// Construct an ``IntegerBytesCollection`` representing the bytes of this integer.
-    @inlinable
     public init(_ integer: Integer) {
         self.integer = integer
     }
@@ -187,7 +186,7 @@ extension IntegerBytesCollection: RandomAccessCollection {
         @usableFromInline
         var _byteNumber: Int
 
-        @inlinable
+        @usableFromInline
         init(byteNumber: Int) {
             self._byteNumber = byteNumber
         }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
@@ -32,6 +32,7 @@ public struct ASN1Null: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, 
         guard content.count == 0 else {
             throw ASN1Error.invalidASN1Object(reason: "ASN1Null must be empty, received \(content.count) bytes")
         }
+        self = .init()
     }
 
     @inlinable

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Null.swift
@@ -20,7 +20,6 @@ public struct ASN1Null: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, 
     }
 
     /// Construct a new ASN.1 null.
-    @inlinable
     public init() {}
 
     @inlinable

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1OctetString.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1OctetString.swift
@@ -23,7 +23,6 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     /// The octets that make up this OCTET STRING.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -36,7 +35,6 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
         self.bytes = content
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -87,7 +85,6 @@ public struct ASN1OctetString: DERImplicitlyTaggable, BERImplicitlyTaggable {
     ///
     /// - parameters:
     ///     - contentBytes: The bytes that make up this OCTET STRING.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }

--- a/Sources/SwiftASN1/Basic ASN1 Types/ASN1Strings.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ASN1Strings.swift
@@ -24,29 +24,24 @@ public struct ASN1UTF8String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hash
     /// The raw bytes that make up this string.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a UTF8STRING from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
 
     /// Construct a UTF8STRING from a String.
-    @inlinable
     public init(_ string: String) {
         self.bytes = ArraySlice(string.utf8)
     }
@@ -77,23 +72,19 @@ public struct ASN1TeletexString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
     /// The raw bytes that make up this string.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a TeletexString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
@@ -132,7 +123,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -140,7 +130,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -149,7 +138,6 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
     }
 
     /// Construct a PrintableString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) throws {
         self.bytes = contentBytes
         guard Self._isValid(self.bytes) else {
@@ -157,14 +145,12 @@ public struct ASN1PrintableString: DERImplicitlyTaggable, BERImplicitlyTaggable,
         }
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
         precondition(Self._isValid(self.bytes))
     }
 
     /// Construct a PrintableString from a String.
-    @inlinable
     public init(_ string: String) throws {
         self.bytes = ArraySlice(string.utf8)
 
@@ -226,7 +212,6 @@ public struct ASN1VisibleString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -234,7 +219,6 @@ public struct ASN1VisibleString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -243,7 +227,6 @@ public struct ASN1VisibleString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
     }
 
     /// Construct a VisibleString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) throws {
         self.bytes = contentBytes
         guard Self._isValid(self.bytes) else {
@@ -251,14 +234,12 @@ public struct ASN1VisibleString: DERImplicitlyTaggable, BERImplicitlyTaggable, H
         }
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
         precondition(Self._isValid(self.bytes))
     }
 
     /// Construct a VisibleString from a String.
-    @inlinable
     public init(_ string: String) throws {
         self.bytes = ArraySlice(string.utf8)
 
@@ -301,23 +282,19 @@ public struct ASN1UniversalString: DERImplicitlyTaggable, BERImplicitlyTaggable,
     /// The raw bytes that make up this string.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a UniversalString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
     }
@@ -348,23 +325,19 @@ public struct ASN1BMPString: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
     /// The raw bytes that make up this string.
     public var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
     }
 
     /// Construct a BMPString from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) {
         self.bytes = contentBytes
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         guard
             value.utf16.allSatisfy({ codeUnit in
@@ -415,7 +388,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(derEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -423,7 +395,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(berEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self.bytes = try ASN1OctetString(berEncoded: node, withIdentifier: identifier).bytes
         guard Self._isValid(self.bytes) else {
@@ -432,7 +403,6 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
     }
 
     /// Construct an IA5String from raw bytes.
-    @inlinable
     public init(contentBytes: ArraySlice<UInt8>) throws {
         self.bytes = contentBytes
         guard Self._isValid(self.bytes) else {
@@ -440,14 +410,12 @@ public struct ASN1IA5String: DERImplicitlyTaggable, BERImplicitlyTaggable, Hasha
         }
     }
 
-    @inlinable
     public init(stringLiteral value: StringLiteralType) {
         self.bytes = ArraySlice(value.utf8)
         precondition(Self._isValid(self.bytes))
     }
 
     /// Construct an IA5String from a String.
-    @inlinable
     public init(_ string: String) throws {
         self.bytes = ArraySlice(string.utf8)
 

--- a/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/GeneralizedTime.swift
@@ -148,7 +148,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     ///     - minutes: The numerical minutes
     ///     - seconds: The numerical seconds
     ///     - fractionalSeconds: The numerical fractional seconds.
-    @inlinable
     public init(
         year: Int,
         month: Int,
@@ -182,7 +181,6 @@ public struct GeneralizedTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Has
     ///     - seconds: The numerical seconds
     ///     - rawFractionalSeconds: The ArraySlice of bytes from which the fractional seconds will be computed.
     ///     (Preserved due to a possible overflow when computing a Double from this ArraySlice.)
-    @inlinable
     public init(
         year: Int,
         month: Int,

--- a/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -35,7 +35,6 @@ public struct ASN1ObjectIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable
     @usableFromInline
     var bytes: ArraySlice<UInt8>
 
-    @inlinable
     public init(derEncoded node: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard node.identifier == identifier else {
             throw ASN1Error.unexpectedFieldType(node.identifier)
@@ -147,7 +146,6 @@ extension ASN1ObjectIdentifier: Sendable {}
 extension ASN1ObjectIdentifier {
     /// Initializes ``ASN1ObjectIdentifier`` from its OID components
     /// - Parameter elements: The OID components
-    @inlinable
     public init(elements: some Collection<UInt>) throws {
         var bytes = [UInt8]()
         var iterator = elements.makeIterator()

--- a/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
+++ b/Sources/SwiftASN1/Basic ASN1 Types/UTCTime.swift
@@ -114,7 +114,6 @@ public struct UTCTime: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     ///     - hours: The numerical hours
     ///     - minutes: The numerical minutes
     ///     - seconds: The numerical seconds
-    @inlinable
     public init(year: Int, month: Int, day: Int, hours: Int, minutes: Int, seconds: Int) throws {
         self._year = year
         self._month = month

--- a/Sources/SwiftASN1/DER.swift
+++ b/Sources/SwiftASN1/DER.swift
@@ -623,7 +623,6 @@ extension DER {
         }
 
         /// Construct a new serializer.
-        @inlinable
         public init() {
             // We allocate a 1kB array because that should cover us most of the time.
             self._serializedBytes = []


### PR DESCRIPTION
**Motivation:**                                                                                              
                                                                                                         
Swift 6.2 enforces stricter definite initialization rules for `@inlinable` initializers under library evolution mode (`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`). Two distinct violations occur across `swift-asn1`:    
                
1. Designated inits that assign stored properties directly, the compiler rejects these as `@inlinable` because the definite initialization proof cannot be verified across module boundaries without `self = .init(...)` syntax.
2. Throwing designated inits that reach a success path without assigning self (for example: `ASN1Null.init(derEncoded:withIdentifier:)`) returns normally after validation but never explicitly sets self, which Swift 6.2 now flags as an error.
         
This prevents `swift-asn1` from compiling as a distributed binary framework (XCFramework or any library evolution target) under Swift 6.2.
                                                                                                         
**Modifications:**  

- @inlinable → `@usableFromInline` (or removed) on designated initializers across `ASN1.swift`, `ASN1BitString.swift`, `ASN1Identifier.swift`, `ASN1Integer.swift`, `ASN1OctetString.swift`, `ASN1Strings.swift`, `GeneralizedTime.swift`, `ObjectIdentifier.swift`, `UTCTime.swift`, and `DER.swift`; these inits assign stored  
properties directly and cannot satisfy @inlinable definite initialization requirements.

- `ASN1Null.init(derEncoded:withIdentifier:)`,  added `self = .init()` at end of success path, keeping the init `@inlinable`.
- `ASN1Any`, extracted a `@usableFromInline` designated `init(_serializedBytes:)`, then converted the two throwing `@inlinable` public inits to delegate via `self.init(_serializedBytes:...)` instead of assigning the stored property directly. Removed `@inlinable` from `init(derEncoded:)` (non-throwing, directly assigns a computed property). 

**Result:**

`swift-asn1` compiles cleanly under Swift 6.2 with library evolution enabled. No behavior change, all public APIs remain callable from inlinable client code via @usableFromInline internal inits.