### PR TITLE
Encode signed integers correctly

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -560,11 +560,18 @@ extension Int {
 }
 
 extension FixedWidthInteger {
-    // Bytes needed to store a given integer.
+    // Bytes needed to store a given integer in DER.
+    // For signed types, an extra 0x00 byte is required when the value is positive and
+    // neededBits is an exact multiple of 8 — meaning the top bit of the minimal
+    // representation is a data bit that DER would otherwise misread as the sign bit.
     @inlinable
     internal var neededBytes: Int {
         let neededBits = self.bitWidth - self.leadingZeroBitCount
-        return (neededBits + 7) / 8
+        let bytes = (neededBits + 7) / 8
+        if Self.isSigned && self > 0 && neededBits > 0 && (neededBits % 8) == 0 {
+            return bytes + 1
+        }
+        return bytes
     }
 }
 

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -948,6 +948,14 @@ class ASN1Tests: XCTestCase {
         }
     }
 
+    func testSignedIntegerRoundtrip() throws {
+        let value: Int64 = 0x80
+        var serializer = DER.Serializer()
+        try serializer.serialize(value)
+        let parsed = try DER.parse(serializer.serializedBytes)
+        XCTAssertEqual(try Int64(derEncoded: parsed), value)
+    }
+
     func testSignedIntegerEncoding() throws {
         // Verify the exact DER byte sequences for signed integer boundary values.
         // Cases where neededBits % 8 == 0 require a leading 0x00 (marked with *).

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -948,6 +948,42 @@ class ASN1Tests: XCTestCase {
         }
     }
 
+    func testSignedIntegerEncoding() throws {
+        // Verify the exact DER byte sequences for signed integer boundary values.
+        // Cases where neededBits % 8 == 0 require a leading 0x00 (marked with *).
+        let cases: [(Int64, [UInt8])] = [
+            // Single-byte positive: top bit clear, no padding needed
+            (0x00, [0x02, 0x01, 0x00]),
+            (0x01, [0x02, 0x01, 0x01]),
+            (0x7F, [0x02, 0x01, 0x7F]),
+            // Single-byte boundary: top bit set, padding needed (*)
+            (0x80, [0x02, 0x02, 0x00, 0x80]),
+            (0xFF, [0x02, 0x02, 0x00, 0xFF]),
+            // Two-byte positive: top bit clear
+            (0x100, [0x02, 0x02, 0x01, 0x00]),
+            (0x7FFF, [0x02, 0x02, 0x7F, 0xFF]),
+            // Two-byte boundary: top bit set, padding needed (*)
+            (0x8000, [0x02, 0x03, 0x00, 0x80, 0x00]),
+            (0xFFFF, [0x02, 0x03, 0x00, 0xFF, 0xFF]),
+            // Negative: no padding, sign carried by top bit
+            (-1, [0x02, 0x01, 0xFF]),
+            (-127, [0x02, 0x01, 0x81]),
+            (-128, [0x02, 0x01, 0x80]),
+            (-129, [0x02, 0x02, 0xFF, 0x7F]),
+            (-32768, [0x02, 0x02, 0x80, 0x00]),
+            (-32769, [0x02, 0x03, 0xFF, 0x7F, 0xFF]),
+        ]
+
+        for (value, expectedBytes) in cases {
+            var serializer = DER.Serializer()
+            try serializer.serialize(value)
+            XCTAssertEqual(serializer.serializedBytes, expectedBytes, "Unexpected encoding for Int64(\(value))")
+
+            let parsed = try DER.parse(serializer.serializedBytes)
+            XCTAssertEqual(try Int64(derEncoded: parsed), value, "Roundtrip failed for Int64(\(value))")
+        }
+    }
+
     func testNotConsumingTaggedObject() throws {
         // We should error if there are two nodes inside an explicitly tagged object.
         let weirdASN1: [UInt8] = [


### PR DESCRIPTION
Motivation:

Currently, positive signed integers whose minimal big-endian representation exactly fills N bytes (`neededBits % 8 == 0`) have their top bit misread as the DER sign bit. `Int64(128)` is therefore encoded as `[0x80]` and decoded back as `-128`. We should fix this.

Modifications:

- Updated the `FixedWidthInteger.neededBytes` implementation to return `bytes + 1` for positive signed integers in this case, causing `IntegerBytesCollection` to emit the required `0x00` sign byte.
- Added associated test cases.

Result:

Positive signed integers whose minimal big-endian representation exactly fills N bytes (`neededBits % 8 == 0`) are now encoded correctly.