### PR TITLE
Throw on truncated BER indefinite length encodings

### DIFF
--- a/Sources/SwiftASN1/ASN1.swift
+++ b/Sources/SwiftASN1/ASN1.swift
@@ -258,6 +258,11 @@ extension ASN1 {
                 repeat {
                     try _parseNode(from: &data, encoding: rules, depth: depth + 1, into: &nodes)
                 } while data.count > 0 && nodes.last!.isEndMarker == false
+                // X.690 §8.1.3.6.1 requires end-of-contents octets. If input is exhausted first,
+                // the last child would otherwise be popped and treated as the marker.
+                guard nodes.last?.isEndMarker == true else {
+                    throw ASN1Error.truncatedASN1Field()
+                }
                 let endMarker = nodes.popLast()!
                 let encodedBytes = originalData[..<endMarker.encodedBytes.endIndex]
                 nodes[lastIndex].encodedBytes = encodedBytes

--- a/Tests/SwiftASN1Tests/ASN1Tests.swift
+++ b/Tests/SwiftASN1Tests/ASN1Tests.swift
@@ -1428,6 +1428,18 @@ class ASN1Tests: XCTestCase {
         XCTAssertThrowsError(try DER.parse(berOctetString))
     }
 
+    func testRejectsTruncatedBERIndefiniteLengthWithoutEndMarker() throws {
+        // SEQUENCE (indefinite), one OCTET STRING child, no end-of-contents octets.
+        let truncated: [UInt8] = [0x30, 0x80, 0x04, 0x01, 0x41]
+        XCTAssertThrowsError(try BER.parse(truncated)) { error in
+            XCTAssertEqual((error as? ASN1Error)?.code, .truncatedASN1Field)
+        }
+
+        // The same encoding with the required EOC marker parses successfully.
+        let complete: [UInt8] = [0x30, 0x80, 0x04, 0x01, 0x41, 0x00, 0x00]
+        XCTAssertNoThrow(try BER.parse(complete))
+    }
+
     func testConstructedBoolean() throws {
         let weirdASN1: [UInt8] = [0x21, 0x00]
         let node = try DER.parse(weirdASN1)


### PR DESCRIPTION
Fixes #125

A truncated BER indefinite length constructed value was parsed as success. The last child was popped and treated as the end of contents marker, so that child disappeared.

The parser now throws truncatedASN1Field when input ends without those octets, matching X.690 section 8.1.3.6.1.

## Test plan
Added testRejectsTruncatedBERIndefiniteLengthWithoutEndMarker. Built the SwiftASN1 product. Full XCTest suite needs Xcode.